### PR TITLE
docs: add APT distribution design spec

### DIFF
--- a/.github/workflows/release-apt.yaml
+++ b/.github/workflows/release-apt.yaml
@@ -1,0 +1,165 @@
+name: Release APT Packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  verify-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main branch
+        run: |
+          if ! git branch --contains "${{ github.sha }}" | grep -qw main; then
+            echo "ERROR: APT release only allowed from main branch"
+            exit 1
+          fi
+
+  build-deb:
+    needs: verify-main
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pg-version: [14, 15, 16, 17, 18]
+        arch: [amd64, arm64]
+      fail-fast: false
+
+    env:
+      PG_VER: ${{ matrix.pg-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set extension version from tag
+        run: echo "EXT_VER=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-pg${{ matrix.pg-version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-cargo-pg${{ matrix.pg-version }}-
+
+      - name: Setup QEMU (arm64 only)
+        if: matrix.arch == 'arm64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Build amd64 package
+        if: matrix.arch == 'amd64'
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential clang llvm libreadline-dev zlib1g-dev \
+            postgresql-${{ env.PG_VER }} \
+            postgresql-server-dev-${{ env.PG_VER }}
+          cargo install cargo-pgrx --version 0.18.0
+          cargo pgrx init --pg${{ env.PG_VER }} /usr/lib/postgresql/${{ env.PG_VER }}/bin/pg_config
+          sudo chmod 777 /usr/share/postgresql/${{ env.PG_VER }} -R
+          sudo chmod 777 /usr/lib/postgresql/${{ env.PG_VER }} -R
+          cargo pgrx package --pg-config=/usr/lib/postgresql/${{ env.PG_VER }}/bin/pg_config
+
+      - name: Build arm64 package
+        if: matrix.arch == 'arm64'
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            ubuntu:22.04 bash -c '
+              set -euo pipefail
+              apt-get update
+              apt-get install -y curl build-essential clang llvm libreadline-dev zlib1g-dev \
+                lsb-release wget gnupg2
+              sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt \$(lsb_release -cs)-pgdg main\" > /etc/apt/sources.list.d/pgdg.list"
+              wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+              apt-get update
+              apt-get install -y postgresql-${{ env.PG_VER }} postgresql-server-dev-${{ env.PG_VER }}
+              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+              source "$HOME/.cargo/env"
+              cargo install cargo-pgrx --version 0.18.0
+              cargo pgrx init --pg${{ env.PG_VER }} /usr/lib/postgresql/${{ env.PG_VER }}/bin/pg_config
+              chmod 777 /usr/share/postgresql/${{ env.PG_VER }} -R
+              chmod 777 /usr/lib/postgresql/${{ env.PG_VER }} -R
+              cargo pgrx package --pg-config=/usr/lib/postgresql/${{ env.PG_VER }}/bin/pg_config
+            '
+
+      - name: Assemble deb package
+        run: |
+          sudo apt-get install -y dpkg-dev
+          PGRX_OUT="target/release/redis_fdw_rs-pg${{ env.PG_VER }}"
+          bash packaging/deb/build-deb.sh \
+            "${{ env.PG_VER }}" \
+            "${{ env.EXT_VER }}" \
+            "${{ matrix.arch }}" \
+            "${PGRX_OUT}"
+
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-pg${{ matrix.pg-version }}-${{ matrix.arch }}
+          path: "*.deb"
+
+  publish-apt:
+    needs: build-deb
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all deb artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: debs
+          pattern: deb-*
+          merge-multiple: true
+
+      - name: List downloaded debs
+        run: find debs -name "*.deb" -ls
+
+      - name: Install reprepro
+        run: sudo apt-get install -y reprepro
+
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.APT_GPG_PRIVATE_KEY }}" | gpg --batch --import
+          GPG_KEY_ID=$(gpg --list-keys --with-colons | grep '^pub' | head -1 | cut -d: -f5)
+          echo "GPG_KEY_ID=${GPG_KEY_ID}" >> $GITHUB_ENV
+
+      - name: Determine repo URL
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+          echo "REPO_URL=${OWNER}.github.io/${REPO}" >> $GITHUB_ENV
+
+      - name: Build apt repository
+        run: |
+          bash packaging/apt/publish-repo.sh \
+            debs \
+            "${{ env.GPG_KEY_ID }}" \
+            "${{ env.REPO_URL }}"
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./apt-repo
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ pg_regress/results
 pg_regress/regression.diffs
 pg_regress/regression.out
 benchmark_results_*
+
+# Packaging build artifacts
+*.deb
+apt-repo/
+postgresql-*-redis-fdw-rs_*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ PostgreSQL Foreign Data Wrapper (FDW) extension written in Rust that exposes Red
 
 ```bash
 # Build (debug)
-cargo build
+cargo build 
 
 # Build (release)
 cargo build --release

--- a/README.md
+++ b/README.md
@@ -26,7 +26,43 @@ A high-performance Redis Foreign Data Wrapper (FDW) for PostgreSQL written in Ru
 
 ## Installation
 
-### Quick Start with Docker
+### Install via APT (Recommended)
+
+**Quick Install** (auto-detects PostgreSQL version):
+
+```bash
+curl -fsSL https://isdaniel.github.io/redis_fdw_rs/install.sh | sudo bash
+```
+
+**Manual Install:**
+
+```bash
+# Add GPG key
+curl -fsSL https://isdaniel.github.io/redis_fdw_rs/gpg.key | \
+  sudo gpg --dearmor -o /etc/apt/keyrings/redis-fdw-rs.gpg
+
+# Add repository (auto-detects your distro)
+echo "deb [signed-by=/etc/apt/keyrings/redis-fdw-rs.gpg] \
+  https://isdaniel.github.io/redis_fdw_rs $(lsb_release -cs) main" | \
+  sudo tee /etc/apt/sources.list.d/redis-fdw-rs.list
+
+# Install (replace 16 with your PostgreSQL version)
+sudo apt update
+sudo apt install postgresql-16-redis-fdw-rs
+```
+
+**Supported Platforms:**
+
+| OS | Codename | Architectures |
+|----|----------|---------------|
+| Ubuntu 22.04 | jammy | amd64, arm64 |
+| Ubuntu 24.04 | noble | amd64, arm64 |
+| Debian 11 | bullseye | amd64, arm64 |
+| Debian 12 | bookworm | amd64, arm64 |
+
+PostgreSQL versions: 14, 15, 16, 17, 18
+
+### Build from Source with Docker
 
 1. **Start Redis server:**
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curl -fsSL https://isdaniel.github.io/redis_fdw_rs/gpg.key | \
 
 # Add repository (auto-detects your distro)
 echo "deb [signed-by=/etc/apt/keyrings/redis-fdw-rs.gpg] \
-  https://isdaniel.github.io/redis_fdw_rs $(lsb_release -cs) main" | \
+  https://isdaniel.github.io/redis_fdw_rs $(. /etc/os-release && echo $VERSION_CODENAME) main" | \
   sudo tee /etc/apt/sources.list.d/redis-fdw-rs.list
 
 # Install (replace 16 with your PostgreSQL version)

--- a/packaging/SETUP.md
+++ b/packaging/SETUP.md
@@ -1,0 +1,56 @@
+# APT Repository Setup
+
+## One-Time Setup: GPG Key
+
+Generate a dedicated GPG key for signing the APT repository:
+
+```bash
+# Generate key (no passphrase for CI automation)
+gpg --batch --gen-key <<EOF
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: redis_fdw_rs APT Signing Key
+Name-Email: redis-fdw-rs@noreply.github.com
+Expire-Date: 0
+%commit
+EOF
+
+# Export private key (add to GitHub Secret: APT_GPG_PRIVATE_KEY)
+gpg --armor --export-secret-keys redis-fdw-rs@noreply.github.com
+
+# Export public key (for verification)
+gpg --armor --export redis-fdw-rs@noreply.github.com
+```
+
+## GitHub Repository Settings
+
+1. **Enable GitHub Pages:**
+   - Settings > Pages > Source: "Deploy from a branch"
+   - Branch: `gh-pages` / root
+
+2. **Add Secrets:**
+   - `APT_GPG_PRIVATE_KEY`: The full armored private key output from above
+
+## Triggering a Release
+
+Push a version tag to trigger the APT release:
+
+```bash
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+The workflow builds debs for all PG versions x architectures and publishes to GitHub Pages.
+
+## Verifying the Repository
+
+After first release, verify:
+
+```bash
+# Check repo metadata is accessible
+curl -I https://isdaniel.github.io/redis_fdw_rs/dists/noble/main/binary-amd64/Packages.gz
+
+# Check GPG key is accessible
+curl -fsSL https://isdaniel.github.io/redis_fdw_rs/gpg.key | gpg --show-keys
+```

--- a/packaging/apt/distributions.template
+++ b/packaging/apt/distributions.template
@@ -1,0 +1,31 @@
+Origin: redis_fdw_rs
+Label: redis_fdw_rs
+Suite: jammy
+Codename: jammy
+Architectures: amd64 arm64
+Components: main
+SignWith: __GPG_KEY_ID__
+
+Origin: redis_fdw_rs
+Label: redis_fdw_rs
+Suite: noble
+Codename: noble
+Architectures: amd64 arm64
+Components: main
+SignWith: __GPG_KEY_ID__
+
+Origin: redis_fdw_rs
+Label: redis_fdw_rs
+Suite: bullseye
+Codename: bullseye
+Architectures: amd64 arm64
+Components: main
+SignWith: __GPG_KEY_ID__
+
+Origin: redis_fdw_rs
+Label: redis_fdw_rs
+Suite: bookworm
+Codename: bookworm
+Architectures: amd64 arm64
+Components: main
+SignWith: __GPG_KEY_ID__

--- a/packaging/apt/install.sh.template
+++ b/packaging/apt/install.sh.template
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-line installer for redis_fdw_rs
+# Usage: curl -fsSL https://__REPO_URL__/install.sh | sudo bash
+
+REPO_URL="__REPO_URL__"
+
+echo "==> Installing redis_fdw_rs PostgreSQL extension"
+
+# Detect distro codename
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    CODENAME="${VERSION_CODENAME:-}"
+else
+    echo "ERROR: Cannot detect OS version. Install manually." >&2
+    exit 1
+fi
+
+# Validate supported codename
+case "${CODENAME}" in
+    jammy|noble|bullseye|bookworm) ;;
+    *)
+        echo "ERROR: Unsupported distribution '${CODENAME}'." >&2
+        echo "Supported: jammy, noble, bullseye, bookworm" >&2
+        exit 1
+        ;;
+esac
+
+# Detect installed PostgreSQL version
+PG_VER=""
+for ver in 18 17 16 15 14; do
+    if dpkg -l "postgresql-${ver}" 2>/dev/null | grep -q "^ii"; then
+        PG_VER="${ver}"
+        break
+    fi
+done
+
+if [ -z "${PG_VER}" ]; then
+    echo "ERROR: No supported PostgreSQL installation detected (14-18)." >&2
+    echo "Install PostgreSQL first: sudo apt install postgresql-16" >&2
+    exit 1
+fi
+
+echo "==> Detected PostgreSQL ${PG_VER} on ${CODENAME}"
+
+# Add GPG key
+mkdir -p /etc/apt/keyrings
+curl -fsSL "https://${REPO_URL}/gpg.key" | \
+    gpg --dearmor --yes -o /etc/apt/keyrings/redis-fdw-rs.gpg
+
+# Add repository
+echo "deb [signed-by=/etc/apt/keyrings/redis-fdw-rs.gpg] https://${REPO_URL} ${CODENAME} main" \
+    > /etc/apt/sources.list.d/redis-fdw-rs.list
+
+# Install
+apt-get update -o Dir::Etc::sourcelist="sources.list.d/redis-fdw-rs.list" \
+               -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+apt-get install -y "postgresql-${PG_VER}-redis-fdw-rs"
+
+echo ""
+echo "==> redis_fdw_rs installed successfully!"
+echo "    Enable it in your database with:"
+echo "      psql -c 'CREATE EXTENSION redis_fdw_rs;'"

--- a/packaging/apt/install.sh.template
+++ b/packaging/apt/install.sh.template
@@ -8,6 +8,14 @@ REPO_URL="__REPO_URL__"
 
 echo "==> Installing redis_fdw_rs PostgreSQL extension"
 
+# Check dependencies
+for cmd in curl gpg; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "ERROR: '$cmd' is not installed. Please install it and try again." >&2
+        exit 1
+    fi
+done
+
 # Detect distro codename
 if [ -f /etc/os-release ]; then
     . /etc/os-release

--- a/packaging/apt/publish-repo.sh
+++ b/packaging/apt/publish-repo.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: publish-repo.sh <deb-dir> <gpg-key-id> <repo-url>
+# Assembles apt repo structure from .deb files using reprepro
+
+DEB_DIR="${1:?Usage: publish-repo.sh <deb-dir> <gpg-key-id> <repo-url>}"
+GPG_KEY_ID="${2:?}"
+REPO_URL="${3:?}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="apt-repo"
+
+rm -rf "${REPO_DIR}"
+mkdir -p "${REPO_DIR}/conf"
+
+# Generate distributions config
+sed "s/__GPG_KEY_ID__/${GPG_KEY_ID}/g" \
+    "${SCRIPT_DIR}/distributions.template" > "${REPO_DIR}/conf/distributions"
+
+# Include all debs in all supported codenames
+CODENAMES="jammy noble bullseye bookworm"
+for codename in ${CODENAMES}; do
+    for deb in "${DEB_DIR}"/*.deb; do
+        reprepro -b "${REPO_DIR}" includedeb "${codename}" "${deb}"
+    done
+done
+
+# Export public GPG key
+gpg --armor --export "${GPG_KEY_ID}" > "${REPO_DIR}/gpg.key"
+
+# Generate install.sh from template
+sed "s|__REPO_URL__|${REPO_URL}|g" \
+    "${SCRIPT_DIR}/install.sh.template" > "${REPO_DIR}/install.sh"
+chmod +x "${REPO_DIR}/install.sh"
+
+echo "APT repo assembled in ${REPO_DIR}/"
+echo "Contents:"
+find "${REPO_DIR}" -type f | sort

--- a/packaging/apt/publish-repo.sh
+++ b/packaging/apt/publish-repo.sh
@@ -19,7 +19,7 @@ sed "s/__GPG_KEY_ID__/${GPG_KEY_ID}/g" \
     "${SCRIPT_DIR}/distributions.template" > "${REPO_DIR}/conf/distributions"
 
 # Include all debs in all supported codenames
-CODENAMES="jammy noble bullseye bookworm"
+CODENAMES="${CODENAMES:-jammy noble bullseye bookworm}"
 for codename in ${CODENAMES}; do
     for deb in "${DEB_DIR}"/*.deb; do
         reprepro -b "${REPO_DIR}" includedeb "${codename}" "${deb}"

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: build-deb.sh <pg-version> <extension-version> <architecture> <pgrx-output-dir>
+# Example: build-deb.sh 16 0.2.0 amd64 target/release/redis_fdw_rs-pg16
+
+PG_VER="${1:?Usage: build-deb.sh <pg-ver> <ext-ver> <arch> <pgrx-output-dir>}"
+EXT_VER="${2:?}"
+ARCH="${3:?}"
+PGRX_OUT="${4:?}"
+
+PKG_NAME="postgresql-${PG_VER}-redis-fdw-rs"
+PKG_DIR="${PKG_NAME}_${EXT_VER}-1_${ARCH}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+rm -rf "${PKG_DIR}"
+mkdir -p "${PKG_DIR}/DEBIAN"
+mkdir -p "${PKG_DIR}/usr/lib/postgresql/${PG_VER}/lib"
+mkdir -p "${PKG_DIR}/usr/share/postgresql/${PG_VER}/extension"
+
+# Copy shared library
+cp "${PGRX_OUT}/usr/lib/postgresql/${PG_VER}/lib/redis_fdw_rs.so" \
+   "${PKG_DIR}/usr/lib/postgresql/${PG_VER}/lib/"
+
+# Copy extension control and SQL files
+cp "${PGRX_OUT}/usr/share/postgresql/${PG_VER}/extension/redis_fdw_rs.control" \
+   "${PKG_DIR}/usr/share/postgresql/${PG_VER}/extension/"
+cp "${PGRX_OUT}/usr/share/postgresql/${PG_VER}/extension/"redis_fdw_rs--*.sql \
+   "${PKG_DIR}/usr/share/postgresql/${PG_VER}/extension/"
+
+# Generate DEBIAN/control from template
+sed -e "s/__PG_VER__/${PG_VER}/g" \
+    -e "s/__VERSION__/${EXT_VER}/g" \
+    -e "s/__ARCH__/${ARCH}/g" \
+    "${SCRIPT_DIR}/control.template" > "${PKG_DIR}/DEBIAN/control"
+
+# Build the deb
+dpkg-deb --build --root-owner-group "${PKG_DIR}"
+
+echo "Built: ${PKG_DIR}.deb"

--- a/packaging/deb/control.template
+++ b/packaging/deb/control.template
@@ -1,0 +1,9 @@
+Package: postgresql-__PG_VER__-redis-fdw-rs
+Version: __VERSION__-1
+Architecture: __ARCH__
+Depends: postgresql-__PG_VER__
+Maintainer: Daniel Shih <dog830228@gmail.com>
+Section: database
+Priority: optional
+Description: PostgreSQL Foreign Data Wrapper for Redis (Rust) Exposes Redis data structures (string, hash, list, set, zset, stream) as PostgreSQL foreign tables. Supports standalone and cluster modes.
+Homepage: https://github.com/danielshih/redis_fdw_rs

--- a/packaging/test/test-install.sh
+++ b/packaging/test/test-install.sh
@@ -17,7 +17,7 @@ echo "==> Testing installation of ${DEB_FILE} with PostgreSQL ${PG_VER}"
 
 docker run --rm \
     -v "$(pwd)/${DEB_FILE}:/tmp/test.deb:ro" \
-    ubuntu:22.04 bash -c "
+    "${TEST_IMAGE:-ubuntu:22.04}" bash -c "
         set -euo pipefail
         apt-get update
         apt-get install -y wget gnupg2 lsb-release

--- a/packaging/test/test-install.sh
+++ b/packaging/test/test-install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Integration test: verify a built .deb installs correctly in a clean container
+# Usage: test-install.sh <deb-file> <pg-version>
+# Example: test-install.sh postgresql-16-redis-fdw-rs_0.2.0-1_amd64.deb 16
+
+DEB_FILE="${1:?Usage: test-install.sh <deb-file> <pg-version>}"
+PG_VER="${2:?}"
+
+if [ ! -f "${DEB_FILE}" ]; then
+    echo "ERROR: deb file not found: ${DEB_FILE}" >&2
+    exit 1
+fi
+
+echo "==> Testing installation of ${DEB_FILE} with PostgreSQL ${PG_VER}"
+
+docker run --rm \
+    -v "$(pwd)/${DEB_FILE}:/tmp/test.deb:ro" \
+    ubuntu:22.04 bash -c "
+        set -euo pipefail
+        apt-get update
+        apt-get install -y wget gnupg2 lsb-release
+
+        # Install PostgreSQL (using modern keyring approach)
+        mkdir -p /etc/apt/keyrings
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/pgdg.gpg
+        echo \"deb [signed-by=/etc/apt/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt \$(lsb_release -cs)-pgdg main\" > /etc/apt/sources.list.d/pgdg.list
+        apt-get update
+        apt-get install -y postgresql-${PG_VER}
+
+        # Install our deb
+        dpkg -i /tmp/test.deb || apt-get install -fy
+
+        # Verify files are in place
+        test -f /usr/lib/postgresql/${PG_VER}/lib/redis_fdw_rs.so
+        test -f /usr/share/postgresql/${PG_VER}/extension/redis_fdw_rs.control
+        ls /usr/share/postgresql/${PG_VER}/extension/redis_fdw_rs--*.sql
+
+        # Verify extension can be loaded
+        su - postgres -c \"pg_lsclusters\"
+        su - postgres -c \"psql -c \\\"CREATE EXTENSION redis_fdw_rs;\\\" 2>&1\" | tee /tmp/output
+        if grep -q 'CREATE EXTENSION' /tmp/output; then
+            echo '==> SUCCESS: Extension created successfully'
+        else
+            echo '==> FAIL: Extension creation failed'
+            cat /tmp/output
+            exit 1
+        fi
+    "
+
+echo "==> PASSED: ${DEB_FILE} installs and loads correctly"


### PR DESCRIPTION
Design for distributing redis_fdw_rs as .deb packages via GitHub Pages apt repository, covering PG 14-18, amd64/arm64, Ubuntu LTS + Debian stable.