### PR TITLE
Support Redis TTL & FDW option validator &  multi-key mode

### DIFF
--- a/.github/workflows/release-apt.yaml
+++ b/.github/workflows/release-apt.yaml
@@ -99,7 +99,7 @@ jobs:
               ln -fs /usr/share/zoneinfo/UTC /etc/localtime
               apt-get update
               apt-get install -y curl build-essential clang llvm libreadline-dev zlib1g-dev \
-                lsb-release wget gnupg2
+                lsb-release wget gnupg2 pkg-config libssl-dev
               sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt \$(lsb_release -cs)-pgdg main\" > /etc/apt/sources.list.d/pgdg.list"
               wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
               apt-get update

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,16 @@
 
 ## What This Project Is
 
-A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tables. Written in Rust using the [pgrx](https://github.com/pgcentralfoundation/pgrx) framework (v0.16.1). Users create foreign tables with options like `table_type 'hash'` and `table_key_prefix 'user:profiles'`, then use standard SQL (SELECT/INSERT/UPDATE/DELETE) to interact with Redis.
+A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tables. Written in Rust using the [pgrx](https://github.com/pgcentralfoundation/pgrx) framework (v0.18.0). Users create foreign tables with options like `table_type 'hash'` and `table_key_prefix 'user:profiles'`, then use standard SQL (SELECT/INSERT/UPDATE/DELETE) to interact with Redis.
 
 ## Current State
 
 **Feature-complete for all CRUD operations.** All Redis types (String, Hash, List, Set, ZSet) support SELECT, INSERT, UPDATE, DELETE. Stream supports SELECT, INSERT, DELETE only (append-only by design).
 
 ### Recent Work
+- TTL support: table-level default + per-row override via virtual `ttl` column
+- Multi-key pattern queries: glob patterns in `table_key_prefix` for scanning multiple keys
+- DDL-time option validation via `redis_fdw_validator`
 - UPDATE support implemented for all types (except Stream)
 - Cost estimation for query planner (`src/query/cost_estimation.rs`)
 - Connection pooling via R2D2 with global pool manager
@@ -28,7 +31,7 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 docker run -d --name redis-server -p 8899:6379 redis
 
 # pgrx toolchain
-cargo install --locked cargo-pgrx --version 0.16.1
+cargo install --locked cargo-pgrx --version 0.18.0
 cargo pgrx init --pg14=/usr/lib/postgresql/14/bin/pg_config
 ```
 
@@ -53,9 +56,10 @@ cargo fmt                      # format
 | File | Purpose |
 |------|---------|
 | `src/core/handlers.rs` | All PostgreSQL FDW callbacks — the entry point for everything |
+| `src/core/validator.rs` | DDL-time option validation (VALIDATOR function) |
 | `src/tables/interface.rs` | The `RedisTableOperations` trait — defines what each type must implement |
 | `src/tables/types.rs` | `RedisTableType` enum + dispatch methods |
-| `src/core/state_manager.rs` | `RedisFdwState` — holds connection, table type, scan state |
+| `src/core/state_manager.rs` | `RedisFdwState` — holds connection, table type, scan state, TTL, multi-key |
 | `src/query/pushdown.rs` | WHERE clause analysis and optimization |
 
 ### Architecture Diagram
@@ -91,8 +95,8 @@ FDW Callbacks (handlers.rs)
 
 | Crate | Version | Purpose |
 |-------|---------|---------|
-| pgrx | =0.16.1 | PostgreSQL extension framework |
-| redis | 0.32.4 | Redis client (with cluster, streams, r2d2 features) |
+| pgrx | =0.18.0 | PostgreSQL extension framework |
+| redis | 1.2.1 | Redis client (with cluster, streams, r2d2 features) |
 | r2d2 | 0.8.10 | Connection pooling |
 | thiserror | 2.0.12 | Error types |
 | rand | 0.9.2 | Random generation utilities |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ cargo fmt
 ## Key Architecture
 
 ### Module Structure
-- `src/core/` — FDW handler callbacks (`handlers.rs`), state management (`state_manager.rs`), connection pool (`pool_manager.rs`), connection factory (`connection_factory.rs`)
+- `src/core/` — FDW handler callbacks (`handlers.rs`), state management (`state_manager.rs`), connection pool (`pool_manager.rs`), connection factory (`connection_factory.rs`), DDL validator (`validator.rs`)
 - `src/tables/` — Trait interface (`interface.rs`), type enum + dispatch (`types.rs`, `macros.rs`), per-type implementations in `implementations/`
 - `src/query/` — WHERE pushdown (`pushdown.rs`), cost estimation (`cost_estimation.rs`), LIMIT handling (`limit.rs`), scan ops (`scan_ops.rs`)
 - `src/auth/` — Redis authentication
@@ -70,6 +70,27 @@ Dispatch from `RedisTableType` enum uses macros in `src/tables/macros.rs`.
 | Stream  | ✅     | ✅     | ❌     | ✅     |
 
 Stream is append-only; UPDATE returns an error at the trait level and `IsForeignRelUpdatable` omits the UPDATE bit for stream tables.
+
+### TTL Support
+- Table option `ttl` sets default key expiration (seconds); -1 = persist
+- Optional `ttl bigint` column allows per-row override on INSERT/UPDATE
+- On SELECT, the `ttl` column returns remaining seconds (-1 = no expiry, -2 = missing)
+- TTL detection: `detect_ttl_column()` in handlers.rs finds column by name "ttl"
+- TTL stripping: handlers strip the ttl column from data before delegating to table type impl
+
+### Multi-Key Pattern Mode
+- If `table_key_prefix` contains `*`, `?`, or `[`, FDW enters multi-key mode
+- Detection: `is_multi_key_pattern()` in state_manager.rs
+- Scanning uses top-level `SCAN MATCH pattern` to find keys
+- Data stored as flat `DataSet::Filtered(Vec<String>)` with N columns per row
+- First column is always the Redis key name
+- INSERT routes to specific key (first column); DELETE uses `DEL` on the full key
+
+### FDW Validator
+- `redis_fdw_validator_wrapper` — raw C function (not `#[pg_extern]`) with `pg_finfo`
+- SQL type: `(text[], oid)` — PG passes options as `key=value` text array
+- Validates server options (host_port required, cluster_mode boolean)
+- Validates table options (table_type, table_key_prefix required; database 0-15; ttl; batch_size 100-100000)
 
 ## Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A high-performance Redis Foreign Data Wrapper (FDW) for PostgreSQL written in Ru
 - **Redis data types support**: Hash, List, Set, ZSet, String, and Stream (with varying levels of implementation)
 - **Redis Streams support**: Full implementation with large data set handling, pagination, and time-based queries
 - **Large data set optimization**: Configurable batch processing and streaming access for Redis Streams
+- **TTL support**: Table-level default TTL via OPTIONS + per-row override via virtual `ttl` column
+- **Multi-key pattern queries**: Auto-detect glob patterns (`*`, `?`, `[`) in `table_key_prefix` to query multiple Redis keys
+- **DDL-time option validation**: FDW validator function checks all options at CREATE time
 - **Supported operations**: SELECT, INSERT, UPDATE, DELETE (UPDATE supported for all types except Stream)
 - **Connection management** and memory optimization
 - **Built with Rust** for memory safety and performance
@@ -269,7 +272,8 @@ OPTIONS (
 ### 1. Create Foreign Data Wrapper
 ```sql
 CREATE FOREIGN DATA WRAPPER redis_wrapper 
-HANDLER redis_fdw_handler;
+HANDLER redis_fdw_handler
+VALIDATOR redis_fdw_validator;
 ```
 
 ### 2. Create Server
@@ -331,6 +335,83 @@ SELECT * FROM user_sessions WHERE field = 'user123';
 ```
 
 ## Supported Redis Data Types (Usage Examples)
+
+### TTL Support
+
+Redis FDW supports key expiration (TTL) at both table level and per-row level:
+
+```sql
+-- Table-level default TTL (all keys expire after 3600 seconds)
+CREATE FOREIGN TABLE cached_data (value text) 
+SERVER redis_server
+OPTIONS (
+    database '0',
+    table_type 'string',
+    table_key_prefix 'cache:item1',
+    ttl '3600'
+);
+
+-- Per-row TTL override via a virtual `ttl` column (bigint)
+CREATE FOREIGN TABLE cached_items (value text, ttl bigint) 
+SERVER redis_server
+OPTIONS (
+    database '0',
+    table_type 'string',
+    table_key_prefix 'cache:item2',
+    ttl '3600'
+);
+
+-- Insert with custom TTL (overrides table default)
+INSERT INTO cached_items VALUES ('short-lived', 60);
+
+-- Remove TTL (persist key forever) by setting ttl = -1
+UPDATE cached_items SET value = 'permanent', ttl = -1;
+
+-- SELECT shows remaining TTL in the ttl column
+SELECT value, ttl FROM cached_items;
+```
+
+**TTL Behavior:**
+- `ttl` table option sets the default expiration (seconds) applied on INSERT/UPDATE
+- A `ttl bigint` column allows per-row override: positive = seconds, -1 = persist, NULL = use default
+- On SELECT, the `ttl` column shows the remaining time-to-live (-1 = no expiry, -2 = key missing)
+
+### Multi-Key Pattern Queries
+
+When `table_key_prefix` contains glob characters (`*`, `?`, `[`), the FDW automatically enters multi-key mode and scans matching keys:
+
+```sql
+-- Query all keys matching the pattern user:*
+CREATE FOREIGN TABLE all_users (key text, value text) 
+SERVER redis_server
+OPTIONS (
+    database '0',
+    table_type 'string',
+    table_key_prefix 'user:*'
+);
+
+-- SELECT returns rows from all matching keys
+SELECT * FROM all_users;
+--  key       | value
+-- -----------+-------
+--  user:1    | alice
+--  user:2    | bob
+
+-- INSERT creates a new key
+INSERT INTO all_users VALUES ('user:3', 'charlie');
+
+-- DELETE removes the entire Redis key
+DELETE FROM all_users WHERE key = 'user:2';
+```
+
+**Multi-key columns per type:**
+| Table Type | Columns |
+|-----------|---------|
+| String | key, value |
+| Hash | key, field, value |
+| List | key, element |
+| Set | key, member |
+| ZSet | key, score, member |
 
 ### Table Type Characteristics
 

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -569,13 +569,20 @@ unsafe extern "C-unwind" fn exec_foreign_update(
 
     log!("Update: old_key={:?}, new_data={:?}", old_key, new_data);
 
-    if let Err(e) = state.update_data(std::slice::from_ref(&old_key), &new_data) {
-        error!("Failed to update data: {:?}", e);
+    if state.is_multi_key {
+        if let Err(e) =
+            state.update_data_to_key(&old_key, std::slice::from_ref(&old_key), &new_data)
+        {
+            error!("Failed to update data for key '{}': {:?}", old_key, e);
+        }
+        state.apply_ttl(&old_key, row_ttl);
+    } else {
+        if let Err(e) = state.update_data(std::slice::from_ref(&old_key), &new_data) {
+            error!("Failed to update data: {:?}", e);
+        }
+        let key = state.table_key_prefix.clone();
+        state.apply_ttl(&key, row_ttl);
     }
-
-    // Apply TTL after successful update
-    let key = state.table_key_prefix.clone();
-    state.apply_ttl(&key, row_ttl);
 
     (*slot).tts_tableOid = pgrx::pg_sys::InvalidOid;
     slot

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -19,6 +19,18 @@ unsafe fn state_from_ptr<'a>(ptr: *mut std::os::raw::c_void) -> &'a mut RedisFdw
     &mut *(ptr as *mut RedisFdwState)
 }
 
+unsafe fn detect_ttl_column(tupdesc: pg_sys::TupleDesc) -> Option<usize> {
+    let natts = (*tupdesc).natts as usize;
+    for i in 0..natts {
+        let attr = tuple_desc_attr(tupdesc, i);
+        let name = pgrx::name_data_to_str(&(*attr).attname);
+        if name == "ttl" {
+            return Some(i);
+        }
+    }
+    None
+}
+
 const REDISMODY: &str = "__redis_UD_key_name";
 
 pub type FdwRoutine<A = AllocatedByRust> = PgBox<pgrx::pg_sys::FdwRoutine, A>;
@@ -240,6 +252,11 @@ extern "C-unwind" fn begin_foreign_scan(
             state.set_table_type();
         });
 
+        // Detect TTL column
+        let relation = (*node).ss.ss_currentRelation;
+        let tupdesc = (*relation).rd_att;
+        state.ttl_column_index = detect_ttl_column(tupdesc);
+
         log!("Connected to Redis");
         (*node).fdw_state = state_ptr;
     }
@@ -271,9 +288,46 @@ unsafe extern "C-unwind" fn iterate_foreign_scan(
         return slot;
     }
 
-    if let Some(row_data) = state.get_row(state.row_count as usize) {
-        for (col_idx, value) in row_data.iter().enumerate() {
-            write_datum_to_slot(slot, tupdesc, col_idx, value.as_ref());
+    let natts = (*tupdesc).natts as usize;
+
+    if state.is_multi_key {
+        let cols_per_row = state.multi_key_columns_per_row();
+        let row_offset = state.row_count as usize * cols_per_row;
+        let dataset = state.table_type.get_dataset_ref();
+        if let Some(flat_data) = dataset.as_filtered() {
+            if row_offset + cols_per_row <= flat_data.len() {
+                // Clone the row slice to release the borrow on state
+                let row_slice: Vec<String> =
+                    flat_data[row_offset..row_offset + cols_per_row].to_vec();
+                let mut data_idx = 0;
+                for col_idx in 0..natts {
+                    if state.ttl_column_index == Some(col_idx) {
+                        let key = &row_slice[0]; // first col is always the key
+                        let ttl_value = state.read_ttl(key);
+                        write_datum_to_slot(slot, tupdesc, col_idx, &ttl_value.to_string());
+                    } else if data_idx < cols_per_row {
+                        write_datum_to_slot(slot, tupdesc, col_idx, &row_slice[data_idx]);
+                        data_idx += 1;
+                    }
+                }
+            } else {
+                return slot;
+            }
+        } else {
+            return slot;
+        }
+    } else if let Some(row_data) = state.get_row(state.row_count as usize) {
+        let row_data: Vec<String> = row_data.iter().map(|c| c.to_string()).collect();
+        let mut data_idx = 0;
+        for col_idx in 0..natts {
+            if state.ttl_column_index == Some(col_idx) {
+                let key = state.table_key_prefix.clone();
+                let ttl_value = state.read_ttl(&key);
+                write_datum_to_slot(slot, tupdesc, col_idx, &ttl_value.to_string());
+            } else if data_idx < row_data.len() {
+                write_datum_to_slot(slot, tupdesc, col_idx, &row_data[data_idx]);
+                data_idx += 1;
+            }
         }
     } else {
         error!(
@@ -393,6 +447,12 @@ unsafe extern "C-unwind" fn begin_foreign_modify(
     state.key_attno =
         pg_sys::ExecFindJunkAttributeInTlist((*subplan).targetlist, REDISMODY.as_ptr() as _);
     log!("Key attribute number: {}", state.key_attno);
+
+    // Detect TTL column in the target relation
+    let relation = (*rinfo).ri_RelationDesc;
+    let tupdesc = (*relation).rd_att;
+    state.ttl_column_index = detect_ttl_column(tupdesc);
+
     (*rinfo).ri_FdwState = state_ptr;
 }
 
@@ -412,16 +472,49 @@ unsafe extern "C-unwind" fn exec_foreign_insert(
     let state = state_from_ptr((*rinfo).ri_FdwState);
     let row: Row = tuple_table_slot_to_row(slot);
 
-    // Convert row cells to string data
-    let data: Vec<String> = row
+    let all_data: Vec<String> = row
         .cells
         .iter()
         .map(|cell| cell_to_string(cell.as_ref()))
         .collect();
 
-    // Use the new unified insert method
-    if let Err(e) = state.insert_data(&data) {
-        error!("Failed to insert data: {:?}", e);
+    // Extract and strip TTL column value
+    let (data, row_ttl) = if let Some(ttl_idx) = state.ttl_column_index {
+        let ttl_val = all_data.get(ttl_idx).and_then(|s| {
+            if s == "NULL" {
+                None
+            } else {
+                s.parse::<i64>().ok()
+            }
+        });
+        let filtered: Vec<String> = all_data
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != ttl_idx)
+            .map(|(_, v)| v.clone())
+            .collect();
+        (filtered, ttl_val)
+    } else {
+        (all_data, None)
+    };
+
+    if state.is_multi_key {
+        // Multi-key mode: first column is the Redis key, remaining columns are data
+        if data.is_empty() {
+            error!("Multi-key INSERT requires at least a key column");
+        }
+        let key = data[0].clone();
+        let row_data = &data[1..];
+        if let Err(e) = state.insert_data_to_key(&key, row_data) {
+            error!("Failed to insert data to key '{}': {:?}", key, e);
+        }
+        state.apply_ttl(&key, row_ttl);
+    } else {
+        if let Err(e) = state.insert_data(&data) {
+            error!("Failed to insert data: {:?}", e);
+        }
+        let key = state.table_key_prefix.clone();
+        state.apply_ttl(&key, row_ttl);
     }
 
     (*slot).tts_tableOid = pgrx::pg_sys::InvalidOid;
@@ -448,17 +541,41 @@ unsafe extern "C-unwind" fn exec_foreign_update(
 
     // Extract new row from the slot
     let new_row: Row = tuple_table_slot_to_row(slot);
-    let new_data: Vec<String> = new_row
+    let all_new_data: Vec<String> = new_row
         .cells
         .iter()
         .map(|cell| cell_to_string(cell.as_ref()))
         .collect();
+
+    // Extract and strip TTL column value
+    let (new_data, row_ttl) = if let Some(ttl_idx) = state.ttl_column_index {
+        let ttl_val = all_new_data.get(ttl_idx).and_then(|s| {
+            if s == "NULL" {
+                None
+            } else {
+                s.parse::<i64>().ok()
+            }
+        });
+        let filtered: Vec<String> = all_new_data
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != ttl_idx)
+            .map(|(_, v)| v.clone())
+            .collect();
+        (filtered, ttl_val)
+    } else {
+        (all_new_data, None)
+    };
 
     log!("Update: old_key={:?}, new_data={:?}", old_key, new_data);
 
     if let Err(e) = state.update_data(std::slice::from_ref(&old_key), &new_data) {
         error!("Failed to update data: {:?}", e);
     }
+
+    // Apply TTL after successful update
+    let key = state.table_key_prefix.clone();
+    state.apply_ttl(&key, row_ttl);
 
     (*slot).tts_tableOid = pgrx::pg_sys::InvalidOid;
     slot
@@ -481,12 +598,21 @@ unsafe extern "C-unwind" fn exec_foreign_delete(
         Ok(key) => {
             log!("Attempting to delete key: '{}'", key);
 
-            // Perform the deletion operation
-            if let Err(e) = state.delete_data(std::slice::from_ref(&key)) {
+            if state.is_multi_key {
+                // Multi-key mode: DEL the entire Redis key
+                if let Some(conn) = state.redis_connection.as_mut() {
+                    let conn_like = conn.as_connection_like_mut();
+                    let result: Result<(), _> = redis::cmd("DEL").arg(&key).query(conn_like);
+                    if let Err(e) = result {
+                        error!("Failed to delete Redis key '{}': {:?}", key, e);
+                    }
+                } else {
+                    error!("Redis connection not available for delete");
+                }
+            } else if let Err(e) = state.delete_data(std::slice::from_ref(&key)) {
                 error!("Failed to delete key '{}': {:?}", key, e);
-            } else {
-                log!("Successfully deleted key: '{}'", key);
             }
+            log!("Successfully deleted key: '{}'", key);
         }
         Err(err_msg) => {
             error!("Failed to extract delete key: {}", err_msg);

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -296,17 +296,27 @@ unsafe extern "C-unwind" fn iterate_foreign_scan(
         let dataset = state.table_type.get_dataset_ref();
         if let Some(flat_data) = dataset.as_filtered() {
             if row_offset + cols_per_row <= flat_data.len() {
-                // Clone the row slice to release the borrow on state
-                let row_slice: Vec<String> =
-                    flat_data[row_offset..row_offset + cols_per_row].to_vec();
+                let key = flat_data[row_offset].clone();
+                let ttl_value = if state.ttl_column_index.is_some() {
+                    Some(state.read_ttl(&key))
+                } else {
+                    None
+                };
+
+                let dataset = state.table_type.get_dataset_ref();
+                let flat_data = dataset.as_filtered().unwrap();
                 let mut data_idx = 0;
                 for col_idx in 0..natts {
                     if state.ttl_column_index == Some(col_idx) {
-                        let key = &row_slice[0]; // first col is always the key
-                        let ttl_value = state.read_ttl(key);
-                        write_datum_to_slot(slot, tupdesc, col_idx, &ttl_value.to_string());
+                        let ttl_str = ttl_value.unwrap().to_string();
+                        write_datum_to_slot(slot, tupdesc, col_idx, &ttl_str);
                     } else if data_idx < cols_per_row {
-                        write_datum_to_slot(slot, tupdesc, col_idx, &row_slice[data_idx]);
+                        write_datum_to_slot(
+                            slot,
+                            tupdesc,
+                            col_idx,
+                            &flat_data[row_offset + data_idx],
+                        );
                         data_idx += 1;
                     }
                 }
@@ -316,25 +326,31 @@ unsafe extern "C-unwind" fn iterate_foreign_scan(
         } else {
             return slot;
         }
-    } else if let Some(row_data) = state.get_row(state.row_count as usize) {
-        let row_data: Vec<String> = row_data.iter().map(|c| c.to_string()).collect();
-        let mut data_idx = 0;
-        for col_idx in 0..natts {
-            if state.ttl_column_index == Some(col_idx) {
-                let key = state.table_key_prefix.clone();
-                let ttl_value = state.read_ttl(&key);
-                write_datum_to_slot(slot, tupdesc, col_idx, &ttl_value.to_string());
-            } else if data_idx < row_data.len() {
-                write_datum_to_slot(slot, tupdesc, col_idx, &row_data[data_idx]);
-                data_idx += 1;
-            }
-        }
     } else {
-        error!(
-            "Failed to get row data at index: {} (data_len={})",
-            state.row_count,
-            state.data_len()
-        );
+        let ttl_value = if state.ttl_column_index.is_some() {
+            let key = state.table_key_prefix.clone();
+            Some(state.read_ttl(&key))
+        } else {
+            None
+        };
+        if let Some(row_data) = state.get_row(state.row_count as usize) {
+            let mut data_idx = 0;
+            for col_idx in 0..natts {
+                if state.ttl_column_index == Some(col_idx) {
+                    let val = ttl_value.unwrap_or(-2);
+                    write_datum_to_slot(slot, tupdesc, col_idx, &val.to_string());
+                } else if data_idx < row_data.len() {
+                    write_datum_to_slot(slot, tupdesc, col_idx, row_data[data_idx].as_ref());
+                    data_idx += 1;
+                }
+            }
+        } else {
+            error!(
+                "Failed to get row data at index: {} (data_len={})",
+                state.row_count,
+                state.data_len()
+            );
+        }
     }
 
     state.row_count += 1;
@@ -487,13 +503,11 @@ unsafe extern "C-unwind" fn exec_foreign_insert(
                 s.parse::<i64>().ok()
             }
         });
-        let filtered: Vec<String> = all_data
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| *i != ttl_idx)
-            .map(|(_, v)| v.clone())
-            .collect();
-        (filtered, ttl_val)
+        let mut data = all_data;
+        if ttl_idx < data.len() {
+            data.remove(ttl_idx);
+        }
+        (data, ttl_val)
     } else {
         (all_data, None)
     };
@@ -556,13 +570,11 @@ unsafe extern "C-unwind" fn exec_foreign_update(
                 s.parse::<i64>().ok()
             }
         });
-        let filtered: Vec<String> = all_new_data
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| *i != ttl_idx)
-            .map(|(_, v)| v.clone())
-            .collect();
-        (filtered, ttl_val)
+        let mut data = all_new_data;
+        if ttl_idx < data.len() {
+            data.remove(ttl_idx);
+        }
+        (data, ttl_val)
     } else {
         (all_new_data, None)
     };

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -328,8 +328,7 @@ unsafe extern "C-unwind" fn iterate_foreign_scan(
         }
     } else {
         let ttl_value = if state.ttl_column_index.is_some() {
-            let key = state.table_key_prefix.clone();
-            Some(state.read_ttl(&key))
+            Some(state.read_ttl(&state.table_key_prefix.clone()))
         } else {
             None
         };
@@ -390,6 +389,8 @@ extern "C-unwind" fn re_scan_foreign_scan(node: *mut pgrx::pg_sys::ForeignScanSt
         state.row_count = 0;
         state.scan_cursor = 0;
         state.scan_complete = false;
+        state.cached_ttl = None;
+        state.multi_key_ttl_cache.clear();
         state.table_type.clear_data();
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,3 +9,4 @@ pub mod connection_factory;
 pub mod handlers;
 pub mod pool_manager;
 pub mod state_manager;
+pub mod validator;

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -37,6 +37,14 @@ pub struct RedisFdwState {
     pub scan_complete: bool,
     /// Batch size for streaming (configurable via table option)
     pub batch_size: usize,
+    /// Column index of the `ttl` column in the tuple descriptor (None = no ttl column)
+    pub ttl_column_index: Option<usize>,
+    /// Default TTL from table OPTIONS (None = no default)
+    pub default_ttl: Option<i64>,
+    /// Whether this table operates in multi-key mode (glob pattern in table_key_prefix)
+    pub is_multi_key: bool,
+    /// Cached TTL value for single-key mode (avoids repeated TTL calls per row)
+    pub cached_ttl: Option<i64>,
 }
 
 impl RedisFdwState {
@@ -56,6 +64,10 @@ impl RedisFdwState {
             scan_cursor: 0,
             scan_complete: false,
             batch_size: 1000,
+            ttl_column_index: None,
+            default_ttl: None,
+            is_multi_key: false,
+            cached_ttl: None,
         }
     }
 
@@ -104,6 +116,16 @@ impl RedisFdwState {
                 self.batch_size = size.clamp(100, 100_000);
             }
         }
+
+        if let Some(ttl_str) = self.opts.get("ttl") {
+            if let Ok(ttl) = ttl_str.parse::<i64>() {
+                if ttl > 0 || ttl == -1 {
+                    self.default_ttl = Some(ttl);
+                }
+            }
+        }
+
+        self.is_multi_key = is_multi_key_pattern(&self.table_key_prefix);
     }
 
     /// Set table type and prepare for streaming iteration
@@ -122,6 +144,10 @@ impl RedisFdwState {
     pub fn fetch_next_batch(&mut self) -> bool {
         if self.scan_complete {
             return false;
+        }
+
+        if self.is_multi_key {
+            return self.fetch_next_batch_multi_key();
         }
 
         // Determine strategy before borrowing connection
@@ -245,7 +271,18 @@ impl RedisFdwState {
 
     /// Get the total number of data items
     pub fn data_len(&self) -> usize {
-        self.table_type.data_len()
+        if self.is_multi_key {
+            let cols = self.multi_key_columns_per_row();
+            if cols == 0 {
+                return 0;
+            }
+            if let Some(filtered) = self.table_type.get_dataset_ref().as_filtered() {
+                return filtered.len() / cols;
+            }
+            0
+        } else {
+            self.table_type.data_len()
+        }
     }
 
     /// Insert data using the appropriate table type
@@ -326,4 +363,227 @@ impl RedisFdwState {
             estimator.estimate_without_connection()
         }
     }
+
+    /// Fetch next batch in multi-key mode using top-level SCAN.
+    fn fetch_next_batch_multi_key(&mut self) -> bool {
+        // Take connection out temporarily to avoid borrow conflicts
+        let mut conn = match self.redis_connection.take() {
+            Some(c) => c,
+            None => {
+                self.scan_complete = true;
+                return false;
+            }
+        };
+
+        let result = self.fetch_multi_key_with_conn(conn.as_connection_like_mut());
+
+        // Put connection back
+        self.redis_connection = Some(conn);
+        result
+    }
+
+    fn fetch_multi_key_with_conn(&mut self, conn: &mut dyn redis::ConnectionLike) -> bool {
+        loop {
+            pgrx::check_for_interrupts!();
+
+            let mut cmd = redis::cmd("SCAN");
+            cmd.arg(self.scan_cursor)
+                .arg("MATCH")
+                .arg(&self.table_key_prefix)
+                .arg("COUNT")
+                .arg(self.batch_size);
+
+            let (new_cursor, keys): (u64, Vec<String>) = match cmd.query(conn) {
+                Ok(result) => result,
+                Err(e) => {
+                    pgrx::error!("Redis error during multi-key SCAN: {}", e);
+                }
+            };
+
+            self.scan_cursor = new_cursor;
+            if new_cursor == 0 {
+                self.scan_complete = true;
+            }
+
+            if keys.is_empty() {
+                if self.scan_complete {
+                    return false;
+                }
+                continue;
+            }
+
+            let rows = self.load_multi_key_data(conn, &keys);
+            if rows > 0 {
+                return true;
+            }
+
+            if self.scan_complete {
+                return false;
+            }
+        }
+    }
+
+    /// Load data for multiple keys and store as flat filtered data.
+    fn load_multi_key_data(
+        &mut self,
+        conn: &mut dyn redis::ConnectionLike,
+        keys: &[String],
+    ) -> usize {
+        let mut all_rows: Vec<String> = Vec::new();
+
+        for key in keys {
+            match &self.table_type {
+                RedisTableType::String(_) => {
+                    let value: Option<String> =
+                        redis::cmd("GET").arg(key).query(conn).unwrap_or(None);
+                    if let Some(v) = value {
+                        all_rows.push(key.clone());
+                        all_rows.push(v);
+                    }
+                }
+                RedisTableType::Hash(_) => {
+                    let pairs: Vec<(String, String)> = redis::cmd("HGETALL")
+                        .arg(key)
+                        .query(conn)
+                        .unwrap_or_default();
+                    for (field, value) in pairs {
+                        all_rows.push(key.clone());
+                        all_rows.push(field);
+                        all_rows.push(value);
+                    }
+                }
+                RedisTableType::List(_) => {
+                    let items: Vec<String> = redis::cmd("LRANGE")
+                        .arg(key)
+                        .arg(0i64)
+                        .arg(-1i64)
+                        .query(conn)
+                        .unwrap_or_default();
+                    for item in items {
+                        all_rows.push(key.clone());
+                        all_rows.push(item);
+                    }
+                }
+                RedisTableType::Set(_) => {
+                    let members: Vec<String> = redis::cmd("SMEMBERS")
+                        .arg(key)
+                        .query(conn)
+                        .unwrap_or_default();
+                    for member in members {
+                        all_rows.push(key.clone());
+                        all_rows.push(member);
+                    }
+                }
+                RedisTableType::ZSet(_) => {
+                    let items: Vec<(String, f64)> = redis::cmd("ZRANGE")
+                        .arg(key)
+                        .arg(0i64)
+                        .arg(-1i64)
+                        .arg("WITHSCORES")
+                        .query(conn)
+                        .unwrap_or_default();
+                    for (member, score) in items {
+                        all_rows.push(key.clone());
+                        all_rows.push(score.to_string());
+                        all_rows.push(member);
+                    }
+                }
+                RedisTableType::Stream(_) | RedisTableType::None => {}
+            }
+        }
+
+        let cols_per_row = self.multi_key_columns_per_row();
+        let row_count = if cols_per_row > 0 {
+            all_rows.len() / cols_per_row
+        } else {
+            0
+        };
+
+        if !all_rows.is_empty() {
+            self.table_type.set_multi_key_data(all_rows);
+        }
+        row_count
+    }
+
+    /// Number of columns per row in multi-key mode (including the key column)
+    pub fn multi_key_columns_per_row(&self) -> usize {
+        match &self.table_type {
+            RedisTableType::String(_) => 2,
+            RedisTableType::Hash(_) => 3,
+            RedisTableType::List(_) => 2,
+            RedisTableType::Set(_) => 2,
+            RedisTableType::ZSet(_) => 3,
+            RedisTableType::Stream(_) => 4,
+            RedisTableType::None => 0,
+        }
+    }
+
+    /// Apply TTL to a Redis key based on per-row value or table default.
+    pub fn apply_ttl(&mut self, key: &str, row_ttl: Option<i64>) {
+        let effective_ttl = match row_ttl {
+            Some(0) => return,
+            Some(t) => t,
+            None => match self.default_ttl {
+                Some(t) => t,
+                None => return,
+            },
+        };
+
+        if let Some(ref mut conn) = self.redis_connection {
+            let conn_like = conn.as_connection_like_mut();
+            if effective_ttl > 0 {
+                let _: Result<(), _> = redis::cmd("EXPIRE")
+                    .arg(key)
+                    .arg(effective_ttl)
+                    .query(conn_like);
+            } else if effective_ttl == -1 {
+                let _: Result<(), _> = redis::cmd("PERSIST").arg(key).query(conn_like);
+            }
+        }
+    }
+
+    /// Read the current TTL for a key. Caches in single-key mode.
+    pub fn read_ttl(&mut self, key: &str) -> i64 {
+        if !self.is_multi_key {
+            if let Some(cached) = self.cached_ttl {
+                return cached;
+            }
+        }
+
+        let ttl = if let Some(ref mut conn) = self.redis_connection {
+            let conn_like = conn.as_connection_like_mut();
+            redis::cmd("TTL")
+                .arg(key)
+                .query::<i64>(conn_like)
+                .unwrap_or(-2)
+        } else {
+            -2
+        };
+
+        if !self.is_multi_key {
+            self.cached_ttl = Some(ttl);
+        }
+        ttl
+    }
+
+    /// Insert data to a specific key (used in multi-key mode)
+    pub fn insert_data_to_key(
+        &mut self,
+        key: &str,
+        data: &[String],
+    ) -> Result<(), redis::RedisError> {
+        if let Some(conn) = self.redis_connection.as_mut() {
+            let conn_like = conn.as_connection_like_mut();
+            self.table_type.insert(conn_like, key, data)
+        } else {
+            Err(redis::RedisError::from((
+                redis::ErrorKind::Io,
+                "Redis connection not initialized",
+            )))
+        }
+    }
+}
+
+pub fn is_multi_key_pattern(prefix: &str) -> bool {
+    prefix.contains('*') || prefix.contains('?') || prefix.contains('[')
 }

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -45,6 +45,8 @@ pub struct RedisFdwState {
     pub is_multi_key: bool,
     /// Cached TTL value for single-key mode (avoids repeated TTL calls per row)
     pub cached_ttl: Option<i64>,
+    /// Cached TTL values for multi-key mode (batch-fetched via pipeline)
+    pub multi_key_ttl_cache: HashMap<String, i64>,
 }
 
 impl RedisFdwState {
@@ -68,6 +70,7 @@ impl RedisFdwState {
             default_ttl: None,
             is_multi_key: false,
             cached_ttl: None,
+            multi_key_ttl_cache: HashMap::new(),
         }
     }
 
@@ -412,6 +415,24 @@ impl RedisFdwState {
                 continue;
             }
 
+            // Batch-fetch TTLs for the scanned keys if TTL column is present
+            if self.ttl_column_index.is_some() {
+                let mut pipe = redis::pipe();
+                for key in &keys {
+                    pipe.cmd("TTL").arg(key);
+                }
+                let ttls: Vec<i64> = match pipe.query(conn) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log!("WARNING: Redis pipeline TTL error: {}", e);
+                        vec![-2; keys.len()]
+                    }
+                };
+                for (key, ttl) in keys.iter().zip(ttls) {
+                    self.multi_key_ttl_cache.insert(key.clone(), ttl);
+                }
+            }
+
             let rows = self.load_multi_key_data(conn, &keys);
             if rows > 0 {
                 return true;
@@ -424,6 +445,7 @@ impl RedisFdwState {
     }
 
     /// Load data for multiple keys and store as flat filtered data.
+    /// Uses Redis pipelining for batch operations to minimize network round-trips.
     fn load_multi_key_data(
         &mut self,
         conn: &mut dyn redis::ConnectionLike,
@@ -448,15 +470,18 @@ impl RedisFdwState {
                 }
             }
             RedisTableType::Hash(_) => {
+                let mut pipe = redis::pipe();
                 for key in keys {
-                    let pairs: Vec<(String, String)> =
-                        match redis::cmd("HGETALL").arg(key).query(conn) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                log!("WARNING: Redis HGETALL error for key '{}': {}", key, e);
-                                continue;
-                            }
-                        };
+                    pipe.cmd("HGETALL").arg(key);
+                }
+                let results: Vec<Vec<(String, String)>> = match pipe.query(conn) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log!("WARNING: Redis pipeline HGETALL error: {}", e);
+                        return 0;
+                    }
+                };
+                for (key, pairs) in keys.iter().zip(results) {
                     for (field, value) in pairs {
                         all_rows.push(key.clone());
                         all_rows.push(field);
@@ -465,19 +490,18 @@ impl RedisFdwState {
                 }
             }
             RedisTableType::List(_) => {
+                let mut pipe = redis::pipe();
                 for key in keys {
-                    let items: Vec<String> = match redis::cmd("LRANGE")
-                        .arg(key)
-                        .arg(0i64)
-                        .arg(-1i64)
-                        .query(conn)
-                    {
-                        Ok(v) => v,
-                        Err(e) => {
-                            log!("WARNING: Redis LRANGE error for key '{}': {}", key, e);
-                            continue;
-                        }
-                    };
+                    pipe.cmd("LRANGE").arg(key).arg(0i64).arg(-1i64);
+                }
+                let results: Vec<Vec<String>> = match pipe.query(conn) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log!("WARNING: Redis pipeline LRANGE error: {}", e);
+                        return 0;
+                    }
+                };
+                for (key, items) in keys.iter().zip(results) {
                     for item in items {
                         all_rows.push(key.clone());
                         all_rows.push(item);
@@ -485,14 +509,18 @@ impl RedisFdwState {
                 }
             }
             RedisTableType::Set(_) => {
+                let mut pipe = redis::pipe();
                 for key in keys {
-                    let members: Vec<String> = match redis::cmd("SMEMBERS").arg(key).query(conn) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            log!("WARNING: Redis SMEMBERS error for key '{}': {}", key, e);
-                            continue;
-                        }
-                    };
+                    pipe.cmd("SMEMBERS").arg(key);
+                }
+                let results: Vec<Vec<String>> = match pipe.query(conn) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log!("WARNING: Redis pipeline SMEMBERS error: {}", e);
+                        return 0;
+                    }
+                };
+                for (key, members) in keys.iter().zip(results) {
                     for member in members {
                         all_rows.push(key.clone());
                         all_rows.push(member);
@@ -500,20 +528,22 @@ impl RedisFdwState {
                 }
             }
             RedisTableType::ZSet(_) => {
+                let mut pipe = redis::pipe();
                 for key in keys {
-                    let items: Vec<(String, f64)> = match redis::cmd("ZRANGE")
+                    pipe.cmd("ZRANGE")
                         .arg(key)
                         .arg(0i64)
                         .arg(-1i64)
-                        .arg("WITHSCORES")
-                        .query(conn)
-                    {
-                        Ok(v) => v,
-                        Err(e) => {
-                            log!("WARNING: Redis ZRANGE error for key '{}': {}", key, e);
-                            continue;
-                        }
-                    };
+                        .arg("WITHSCORES");
+                }
+                let results: Vec<Vec<(String, f64)>> = match pipe.query(conn) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log!("WARNING: Redis pipeline ZRANGE error: {}", e);
+                        return 0;
+                    }
+                };
+                for (key, items) in keys.iter().zip(results) {
                     for (member, score) in items {
                         all_rows.push(key.clone());
                         all_rows.push(score.to_string());
@@ -576,11 +606,14 @@ impl RedisFdwState {
     }
 
     /// Read the current TTL for a key. Caches in single-key mode.
+    /// In multi-key mode, uses pre-fetched cache from `batch_read_ttls`.
     pub fn read_ttl(&mut self, key: &str) -> i64 {
         if !self.is_multi_key {
             if let Some(cached) = self.cached_ttl {
                 return cached;
             }
+        } else if let Some(&cached) = self.multi_key_ttl_cache.get(key) {
+            return cached;
         }
 
         let ttl = if let Some(ref mut conn) = self.redis_connection {

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -431,65 +431,97 @@ impl RedisFdwState {
     ) -> usize {
         let mut all_rows: Vec<String> = Vec::new();
 
-        for key in keys {
-            match &self.table_type {
-                RedisTableType::String(_) => {
-                    let value: Option<String> =
-                        redis::cmd("GET").arg(key).query(conn).unwrap_or(None);
+        match &self.table_type {
+            RedisTableType::String(_) => {
+                let values: Vec<Option<String>> = match redis::cmd("MGET").arg(keys).query(conn) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log!("WARNING: Redis MGET error: {}", e);
+                        return 0;
+                    }
+                };
+                for (key, value) in keys.iter().zip(values) {
                     if let Some(v) = value {
                         all_rows.push(key.clone());
                         all_rows.push(v);
                     }
                 }
-                RedisTableType::Hash(_) => {
-                    let pairs: Vec<(String, String)> = redis::cmd("HGETALL")
-                        .arg(key)
-                        .query(conn)
-                        .unwrap_or_default();
+            }
+            RedisTableType::Hash(_) => {
+                for key in keys {
+                    let pairs: Vec<(String, String)> =
+                        match redis::cmd("HGETALL").arg(key).query(conn) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                log!("WARNING: Redis HGETALL error for key '{}': {}", key, e);
+                                continue;
+                            }
+                        };
                     for (field, value) in pairs {
                         all_rows.push(key.clone());
                         all_rows.push(field);
                         all_rows.push(value);
                     }
                 }
-                RedisTableType::List(_) => {
-                    let items: Vec<String> = redis::cmd("LRANGE")
+            }
+            RedisTableType::List(_) => {
+                for key in keys {
+                    let items: Vec<String> = match redis::cmd("LRANGE")
                         .arg(key)
                         .arg(0i64)
                         .arg(-1i64)
                         .query(conn)
-                        .unwrap_or_default();
+                    {
+                        Ok(v) => v,
+                        Err(e) => {
+                            log!("WARNING: Redis LRANGE error for key '{}': {}", key, e);
+                            continue;
+                        }
+                    };
                     for item in items {
                         all_rows.push(key.clone());
                         all_rows.push(item);
                     }
                 }
-                RedisTableType::Set(_) => {
-                    let members: Vec<String> = redis::cmd("SMEMBERS")
-                        .arg(key)
-                        .query(conn)
-                        .unwrap_or_default();
+            }
+            RedisTableType::Set(_) => {
+                for key in keys {
+                    let members: Vec<String> = match redis::cmd("SMEMBERS").arg(key).query(conn) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            log!("WARNING: Redis SMEMBERS error for key '{}': {}", key, e);
+                            continue;
+                        }
+                    };
                     for member in members {
                         all_rows.push(key.clone());
                         all_rows.push(member);
                     }
                 }
-                RedisTableType::ZSet(_) => {
-                    let items: Vec<(String, f64)> = redis::cmd("ZRANGE")
+            }
+            RedisTableType::ZSet(_) => {
+                for key in keys {
+                    let items: Vec<(String, f64)> = match redis::cmd("ZRANGE")
                         .arg(key)
                         .arg(0i64)
                         .arg(-1i64)
                         .arg("WITHSCORES")
                         .query(conn)
-                        .unwrap_or_default();
+                    {
+                        Ok(v) => v,
+                        Err(e) => {
+                            log!("WARNING: Redis ZRANGE error for key '{}': {}", key, e);
+                            continue;
+                        }
+                    };
                     for (member, score) in items {
                         all_rows.push(key.clone());
                         all_rows.push(score.to_string());
                         all_rows.push(member);
                     }
                 }
-                RedisTableType::Stream(_) | RedisTableType::None => {}
             }
+            RedisTableType::Stream(_) | RedisTableType::None => {}
         }
 
         let cols_per_row = self.multi_key_columns_per_row();

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -493,11 +493,7 @@ impl RedisFdwState {
         }
 
         let cols_per_row = self.multi_key_columns_per_row();
-        let row_count = if cols_per_row > 0 {
-            all_rows.len() / cols_per_row
-        } else {
-            0
-        };
+        let row_count = all_rows.len().checked_div(cols_per_row).unwrap_or(0);
 
         if !all_rows.is_empty() {
             self.table_type.set_multi_key_data(all_rows);
@@ -532,12 +528,17 @@ impl RedisFdwState {
         if let Some(ref mut conn) = self.redis_connection {
             let conn_like = conn.as_connection_like_mut();
             if effective_ttl > 0 {
-                let _: Result<(), _> = redis::cmd("EXPIRE")
+                if let Err(e) = redis::cmd("EXPIRE")
                     .arg(key)
                     .arg(effective_ttl)
-                    .query(conn_like);
+                    .query::<()>(conn_like)
+                {
+                    log!("WARNING: Failed to set EXPIRE on key '{}': {}", key, e);
+                }
             } else if effective_ttl == -1 {
-                let _: Result<(), _> = redis::cmd("PERSIST").arg(key).query(conn_like);
+                if let Err(e) = redis::cmd("PERSIST").arg(key).query::<()>(conn_like) {
+                    log!("WARNING: Failed to PERSIST key '{}': {}", key, e);
+                }
             }
         }
     }
@@ -575,6 +576,23 @@ impl RedisFdwState {
         if let Some(conn) = self.redis_connection.as_mut() {
             let conn_like = conn.as_connection_like_mut();
             self.table_type.insert(conn_like, key, data)
+        } else {
+            Err(redis::RedisError::from((
+                redis::ErrorKind::Io,
+                "Redis connection not initialized",
+            )))
+        }
+    }
+
+    pub fn update_data_to_key(
+        &mut self,
+        key: &str,
+        old_data: &[String],
+        new_data: &[String],
+    ) -> Result<(), redis::RedisError> {
+        if let Some(conn) = self.redis_connection.as_mut() {
+            let conn_like = conn.as_connection_like_mut();
+            self.table_type.update(conn_like, key, old_data, new_data)
         } else {
             Err(redis::RedisError::from((
                 redis::ErrorKind::Io,

--- a/src/core/validator.rs
+++ b/src/core/validator.rs
@@ -1,0 +1,239 @@
+use pgrx::pg_sys;
+use pgrx::prelude::*;
+use std::collections::HashMap;
+
+const VALID_TABLE_TYPES: &[&str] = &["string", "hash", "list", "set", "zset", "stream"];
+
+const KNOWN_SERVER_OPTIONS: &[&str] = &["host_port", "password", "username", "cluster_mode"];
+const KNOWN_TABLE_OPTIONS: &[&str] = &[
+    "table_type",
+    "table_key_prefix",
+    "database",
+    "ttl",
+    "batch_size",
+];
+
+// Register the validator function with text[] SQL type so PostgreSQL can find it
+// for the VALIDATOR clause in CREATE FOREIGN DATA WRAPPER.
+pgrx::extension_sql!(
+    "CREATE OR REPLACE FUNCTION redis_fdw_validator(text[], oid) RETURNS void LANGUAGE c AS 'MODULE_PATHNAME', 'redis_fdw_validator_wrapper';",
+    name = "redis_fdw_validator_sql",
+);
+
+/// Raw C wrapper for the FDW validator.
+/// PostgreSQL's FDW VALIDATOR mechanism expects (text[], oid) at SQL level
+/// but actually passes a List* of DefElem* as the first datum at C level.
+#[no_mangle]
+#[pg_guard]
+pub unsafe extern "C-unwind" fn redis_fdw_validator_wrapper(
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> pg_sys::Datum {
+    let args = (*fcinfo).args.as_slice(2);
+
+    let catalog =
+        pg_sys::Oid::from_datum(args[1].value, args[1].isnull).unwrap_or(pg_sys::InvalidOid);
+
+    let opts = parse_options_list_raw(args[0].value, args[0].isnull);
+
+    if catalog == pg_sys::ForeignServerRelationId {
+        validate_server_options(&opts);
+    } else if catalog == pg_sys::ForeignTableRelationId {
+        validate_table_options(&opts);
+    }
+
+    pg_sys::Datum::from(0)
+}
+
+/// Required by PostgreSQL's fmgr to discover the function at runtime.
+#[no_mangle]
+pub extern "C" fn pg_finfo_redis_fdw_validator_wrapper() -> &'static pg_sys::Pg_finfo_record {
+    static FINFO: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
+    &FINFO
+}
+
+unsafe fn parse_options_list_raw(datum: pg_sys::Datum, is_null: bool) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+
+    if is_null {
+        return map;
+    }
+
+    // PostgreSQL passes options as text[] when SQL type is text[]
+    // Each element is formatted as "key=value"
+    let array: Option<pgrx::Array<&str>> = pgrx::Array::from_datum(datum, false);
+    let Some(array) = array else {
+        return map;
+    };
+
+    for item in array.iter().flatten() {
+        if let Some(eq_pos) = item.find('=') {
+            let key = item[..eq_pos].to_string();
+            let value = item[eq_pos + 1..].to_string();
+            map.insert(key, value);
+        }
+    }
+
+    map
+}
+
+fn validate_server_options(opts: &HashMap<String, String>) {
+    if let Some(hp) = opts.get("host_port") {
+        if !validation_rules::is_valid_host_port(hp) {
+            error!("host_port must be in format 'host:port', got '{}'", hp);
+        }
+    } else {
+        error!("missing required option \"host_port\" for redis_fdw server");
+    }
+
+    if let Some(cm) = opts.get("cluster_mode") {
+        if cm != "true" && cm != "false" {
+            error!("cluster_mode must be \"true\" or \"false\", got '{}'", cm);
+        }
+    }
+
+    for key in opts.keys() {
+        if !KNOWN_SERVER_OPTIONS.contains(&key.as_str())
+            && !KNOWN_TABLE_OPTIONS.contains(&key.as_str())
+        {
+            warning!("redis_fdw: unrecognized server option \"{}\"", key);
+        }
+    }
+}
+
+fn validate_table_options(opts: &HashMap<String, String>) {
+    if let Some(tt) = opts.get("table_type") {
+        if !validation_rules::is_valid_table_type(tt) {
+            error!(
+                "invalid table_type \"{}\". Must be one of: string, hash, list, set, zset, stream",
+                tt
+            );
+        }
+    } else {
+        error!("missing required option \"table_type\" for redis_fdw foreign table");
+    }
+
+    if let Some(prefix) = opts.get("table_key_prefix") {
+        if prefix.is_empty() {
+            error!("table_key_prefix must not be empty");
+        }
+    } else {
+        error!("missing required option \"table_key_prefix\" for redis_fdw foreign table");
+    }
+
+    if let Some(db) = opts.get("database") {
+        if !validation_rules::is_valid_database(db) {
+            error!("database must be an integer between 0 and 15, got '{}'", db);
+        }
+    }
+
+    if let Some(ttl_str) = opts.get("ttl") {
+        if !validation_rules::is_valid_ttl(ttl_str) {
+            error!(
+                "ttl must be a positive integer or -1 (persist), got '{}'",
+                ttl_str
+            );
+        }
+    }
+
+    if let Some(bs) = opts.get("batch_size") {
+        if !validation_rules::is_valid_batch_size(bs) {
+            error!("batch_size must be between 100 and 100000, got '{}'", bs);
+        }
+    }
+
+    for key in opts.keys() {
+        if !KNOWN_TABLE_OPTIONS.contains(&key.as_str())
+            && !KNOWN_SERVER_OPTIONS.contains(&key.as_str())
+        {
+            warning!("redis_fdw: unrecognized table option \"{}\"", key);
+        }
+    }
+}
+
+pub mod validation_rules {
+    pub fn is_valid_table_type(s: &str) -> bool {
+        super::VALID_TABLE_TYPES.contains(&s.to_lowercase().as_str())
+    }
+
+    pub fn is_valid_ttl(s: &str) -> bool {
+        match s.parse::<i64>() {
+            Ok(n) => n > 0 || n == -1,
+            Err(_) => false,
+        }
+    }
+
+    pub fn is_valid_batch_size(s: &str) -> bool {
+        match s.parse::<usize>() {
+            Ok(n) => (100..=100_000).contains(&n),
+            Err(_) => false,
+        }
+    }
+
+    pub fn is_valid_database(s: &str) -> bool {
+        match s.parse::<i64>() {
+            Ok(n) => (0..=15).contains(&n),
+            Err(_) => false,
+        }
+    }
+
+    pub fn is_valid_host_port(s: &str) -> bool {
+        !s.is_empty() && s.contains(':')
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validation_rules::*;
+
+    #[test]
+    fn test_valid_table_types() {
+        assert!(is_valid_table_type("string"));
+        assert!(is_valid_table_type("hash"));
+        assert!(is_valid_table_type("list"));
+        assert!(is_valid_table_type("set"));
+        assert!(is_valid_table_type("zset"));
+        assert!(is_valid_table_type("stream"));
+        assert!(is_valid_table_type("STRING"));
+        assert!(is_valid_table_type("Hash"));
+        assert!(!is_valid_table_type("invalid"));
+        assert!(!is_valid_table_type(""));
+    }
+
+    #[test]
+    fn test_valid_ttl() {
+        assert!(is_valid_ttl("3600"));
+        assert!(is_valid_ttl("1"));
+        assert!(is_valid_ttl("-1"));
+        assert!(!is_valid_ttl("0"));
+        assert!(!is_valid_ttl("-5"));
+        assert!(!is_valid_ttl("abc"));
+        assert!(!is_valid_ttl(""));
+    }
+
+    #[test]
+    fn test_valid_batch_size() {
+        assert!(is_valid_batch_size("100"));
+        assert!(is_valid_batch_size("50000"));
+        assert!(is_valid_batch_size("100000"));
+        assert!(!is_valid_batch_size("99"));
+        assert!(!is_valid_batch_size("100001"));
+        assert!(!is_valid_batch_size("abc"));
+    }
+
+    #[test]
+    fn test_valid_database() {
+        assert!(is_valid_database("0"));
+        assert!(is_valid_database("15"));
+        assert!(!is_valid_database("16"));
+        assert!(!is_valid_database("-1"));
+        assert!(!is_valid_database("abc"));
+    }
+
+    #[test]
+    fn test_valid_host_port() {
+        assert!(is_valid_host_port("127.0.0.1:6379"));
+        assert!(is_valid_host_port("redis.example.com:6379"));
+        assert!(!is_valid_host_port(""));
+        assert!(!is_valid_host_port("no-port"));
+    }
+}

--- a/src/core/validator.rs
+++ b/src/core/validator.rs
@@ -21,8 +21,8 @@ pgrx::extension_sql!(
 );
 
 /// Raw C wrapper for the FDW validator.
-/// PostgreSQL's FDW VALIDATOR mechanism expects (text[], oid) at SQL level
-/// but actually passes a List* of DefElem* as the first datum at C level.
+/// PostgreSQL converts the options list to a text[] array (key=value format)
+/// before calling our function, matching the (text[], oid) SQL signature.
 #[no_mangle]
 #[pg_guard]
 pub unsafe extern "C-unwind" fn redis_fdw_validator_wrapper(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod tests;
 
 // Re-export the main FDW handler function for PostgreSQL
 pub use core::handlers::redis_fdw_handler;
+pub use core::validator::redis_fdw_validator_wrapper;
 
 ::pgrx::pg_module_magic!(name, version);
 

--- a/src/tables/types.rs
+++ b/src/tables/types.rs
@@ -120,6 +120,32 @@ impl RedisTableType {
     pub fn supports_pushdown(&self, operator: &ComparisonOperator) -> bool {
         table_dispatch!(self, supports_pushdown(operator) -> false)
     }
+
+    /// Store flat multi-key data (used by multi-key mode)
+    pub fn set_multi_key_data(&mut self, data: Vec<String>) {
+        match self {
+            RedisTableType::String(t) => t.dataset = DataSet::Filtered(data),
+            RedisTableType::Hash(t) => t.dataset = DataSet::Filtered(data),
+            RedisTableType::List(t) => t.dataset = DataSet::Filtered(data),
+            RedisTableType::Set(t) => t.dataset = DataSet::Filtered(data),
+            RedisTableType::ZSet(t) => t.dataset = DataSet::Filtered(data),
+            RedisTableType::Stream(t) => t.dataset = DataSet::Filtered(data),
+            RedisTableType::None => {}
+        }
+    }
+
+    /// Get a reference to the dataset (for multi-key mode)
+    pub fn get_dataset_ref(&self) -> &DataSet {
+        match self {
+            RedisTableType::String(t) => &t.dataset,
+            RedisTableType::Hash(t) => &t.dataset,
+            RedisTableType::List(t) => &t.dataset,
+            RedisTableType::Set(t) => &t.dataset,
+            RedisTableType::ZSet(t) => &t.dataset,
+            RedisTableType::Stream(t) => &t.dataset,
+            RedisTableType::None => &DataSet::Empty,
+        }
+    }
 }
 
 /// Result type for data loading operations
@@ -184,6 +210,13 @@ impl DataSet {
                     .map(|item| vec![Cow::Borrowed(item.as_str())])
             }
             DataSet::Complete(container) => container.get_row(index),
+        }
+    }
+
+    pub fn as_filtered(&self) -> Option<&Vec<String>> {
+        match self {
+            DataSet::Filtered(data) => Some(data),
+            _ => None,
         }
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -43,3 +43,12 @@ pub mod streaming_modify_tests;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub mod pushdown_verification_tests;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod validation_tests;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod ttl_tests;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod multi_key_tests;

--- a/src/tests/multi_key_tests.rs
+++ b/src/tests/multi_key_tests.rs
@@ -1,0 +1,257 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    const REDIS_HOST_PORT: &str = "127.0.0.1:8899";
+    const TEST_DATABASE: &str = "15";
+    const FDW_NAME: &str = "redis_multikey_fdw";
+    const SERVER_NAME: &str = "redis_multikey_server";
+
+    fn setup_fdw() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {} HANDLER redis_fdw_handler VALIDATOR redis_fdw_validator;",
+            FDW_NAME
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '{}');",
+            SERVER_NAME, FDW_NAME, REDIS_HOST_PORT
+        ))
+        .unwrap();
+    }
+
+    fn cleanup() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+    }
+
+    fn seed_redis_keys(prefix: &str, count: usize) {
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        for i in 1..=count {
+            let key = format!("{}:{}", prefix, i);
+            let _: () = redis::cmd("SET")
+                .arg(&key)
+                .arg(format!("value_{}", i))
+                .query(&mut conn)
+                .unwrap();
+        }
+    }
+
+    fn cleanup_redis_keys(prefix: &str, count: usize) {
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        for i in 1..=count {
+            let key = format!("{}:{}", prefix, i);
+            let _: Result<(), _> = redis::cmd("DEL").arg(&key).query(&mut conn);
+        }
+    }
+
+    #[pg_test]
+    fn test_multi_key_string_select() {
+        setup_fdw();
+        let prefix = "mk_test_str";
+        cleanup_redis_keys(prefix, 5);
+        seed_redis_keys(prefix, 5);
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE mk_str_select (key text, value text) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}:*'
+            );",
+            SERVER_NAME, TEST_DATABASE, prefix
+        ))
+        .unwrap();
+
+        let count = Spi::get_one::<i64>("SELECT COUNT(*) FROM mk_str_select;").unwrap();
+        assert_eq!(count, Some(5), "Expected 5 rows, got {:?}", count);
+
+        Spi::run("DROP FOREIGN TABLE mk_str_select;").unwrap();
+        cleanup_redis_keys(prefix, 5);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_multi_key_string_insert() {
+        setup_fdw();
+        let prefix = "mk_test_ins";
+        cleanup_redis_keys(prefix, 3);
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE mk_str_insert (key text, value text) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}:*'
+            );",
+            SERVER_NAME, TEST_DATABASE, prefix
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "INSERT INTO mk_str_insert VALUES ('{}:1', 'inserted_1');",
+            prefix
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "INSERT INTO mk_str_insert VALUES ('{}:2', 'inserted_2');",
+            prefix
+        ))
+        .unwrap();
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let val: Option<String> = redis::cmd("GET")
+            .arg(format!("{}:1", prefix))
+            .query(&mut conn)
+            .unwrap();
+        assert_eq!(val, Some("inserted_1".to_string()));
+
+        let val2: Option<String> = redis::cmd("GET")
+            .arg(format!("{}:2", prefix))
+            .query(&mut conn)
+            .unwrap();
+        assert_eq!(val2, Some("inserted_2".to_string()));
+
+        Spi::run("DROP FOREIGN TABLE mk_str_insert;").unwrap();
+        cleanup_redis_keys(prefix, 3);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_multi_key_string_delete() {
+        setup_fdw();
+        let prefix = "mk_test_del";
+        cleanup_redis_keys(prefix, 3);
+        seed_redis_keys(prefix, 3);
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE mk_str_delete (key text, value text) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}:*'
+            );",
+            SERVER_NAME, TEST_DATABASE, prefix
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "DELETE FROM mk_str_delete WHERE key = '{}:2';",
+            prefix
+        ))
+        .unwrap();
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let exists: bool = redis::cmd("EXISTS")
+            .arg(format!("{}:2", prefix))
+            .query(&mut conn)
+            .unwrap();
+        assert!(!exists, "Key should have been deleted");
+
+        let exists1: bool = redis::cmd("EXISTS")
+            .arg(format!("{}:1", prefix))
+            .query(&mut conn)
+            .unwrap();
+        assert!(exists1, "Key 1 should still exist");
+
+        Spi::run("DROP FOREIGN TABLE mk_str_delete;").unwrap();
+        cleanup_redis_keys(prefix, 3);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_multi_key_hash_select() {
+        setup_fdw();
+        let prefix = "mk_test_hash";
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        for i in 1..=3 {
+            let key = format!("{}:{}", prefix, i);
+            let _: Result<(), _> = redis::cmd("DEL").arg(&key).query(&mut conn);
+            let _: () = redis::cmd("HSET")
+                .arg(&key)
+                .arg("field_a")
+                .arg(format!("val_{}", i))
+                .query(&mut conn)
+                .unwrap();
+        }
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE mk_hash_select (key text, field text, value text) SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}:*'
+            );",
+            SERVER_NAME, TEST_DATABASE, prefix
+        ))
+        .unwrap();
+
+        let count = Spi::get_one::<i64>("SELECT COUNT(*) FROM mk_hash_select;").unwrap();
+        assert_eq!(count, Some(3), "Expected 3 rows, got {:?}", count);
+
+        Spi::run("DROP FOREIGN TABLE mk_hash_select;").unwrap();
+        for i in 1..=3 {
+            let _: Result<(), _> = redis::cmd("DEL")
+                .arg(format!("{}:{}", prefix, i))
+                .query(&mut conn);
+        }
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_multi_key_with_ttl_on_insert() {
+        setup_fdw();
+        let prefix = "mk_test_ttl";
+        cleanup_redis_keys(prefix, 3);
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE mk_str_ttl (key text, value text, ttl bigint) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}:*'
+            );",
+            SERVER_NAME, TEST_DATABASE, prefix
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "INSERT INTO mk_str_ttl VALUES ('{}:1', 'ttl_val', 45);",
+            prefix
+        ))
+        .unwrap();
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let ttl: i64 = redis::cmd("TTL")
+            .arg(format!("{}:1", prefix))
+            .query(&mut conn)
+            .unwrap();
+        assert!(ttl > 0 && ttl <= 45, "Expected TTL 1-45, got {}", ttl);
+
+        Spi::run("DROP FOREIGN TABLE mk_str_ttl;").unwrap();
+        cleanup_redis_keys(prefix, 3);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_is_multi_key_pattern_detection() {
+        use crate::core::state_manager::is_multi_key_pattern;
+
+        assert!(is_multi_key_pattern("prefix:*"));
+        assert!(is_multi_key_pattern("user:?:name"));
+        assert!(is_multi_key_pattern("key:[abc]"));
+        assert!(!is_multi_key_pattern("simple:prefix:"));
+        assert!(!is_multi_key_pattern("no_glob_here"));
+    }
+}

--- a/src/tests/ttl_tests.rs
+++ b/src/tests/ttl_tests.rs
@@ -1,0 +1,238 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    const REDIS_HOST_PORT: &str = "127.0.0.1:8899";
+    const TEST_DATABASE: &str = "15";
+    const FDW_NAME: &str = "redis_ttl_fdw";
+    const SERVER_NAME: &str = "redis_ttl_server";
+
+    fn setup_fdw() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {} HANDLER redis_fdw_handler VALIDATOR redis_fdw_validator;",
+            FDW_NAME
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '{}');",
+            SERVER_NAME, FDW_NAME, REDIS_HOST_PORT
+        ))
+        .unwrap();
+    }
+
+    fn cleanup() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+    }
+
+    fn cleanup_redis_key(key: &str) {
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let _: Result<(), _> = redis::cmd("DEL").arg(key).query(&mut conn);
+    }
+
+    #[pg_test]
+    fn test_ttl_default_via_table_option_string() {
+        setup_fdw();
+        let key = "ttl_test:string:default";
+        cleanup_redis_key(key);
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE ttl_str_default (value text) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}', ttl '60'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+
+        Spi::run("INSERT INTO ttl_str_default VALUES ('hello_ttl');").unwrap();
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let ttl: i64 = redis::cmd("TTL").arg(key).query(&mut conn).unwrap();
+        assert!(ttl > 0 && ttl <= 60, "Expected TTL 1-60, got {}", ttl);
+
+        Spi::run("DROP FOREIGN TABLE ttl_str_default;").unwrap();
+        cleanup_redis_key(key);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_ttl_column_override_string() {
+        setup_fdw();
+        let key = "ttl_test:string:override";
+        cleanup_redis_key(key);
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE ttl_str_override (value text, ttl bigint) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}', ttl '300'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+
+        // Insert with per-row TTL override of 30 seconds
+        Spi::run("INSERT INTO ttl_str_override VALUES ('ttl_override', 30);").unwrap();
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let ttl: i64 = redis::cmd("TTL").arg(key).query(&mut conn).unwrap();
+        assert!(ttl > 0 && ttl <= 30, "Expected TTL 1-30, got {}", ttl);
+
+        Spi::run("DROP FOREIGN TABLE ttl_str_override;").unwrap();
+        cleanup_redis_key(key);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_ttl_persist_via_column() {
+        setup_fdw();
+        let key = "ttl_test:string:persist";
+        cleanup_redis_key(key);
+
+        // First set with TTL
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let _: () = redis::cmd("SET")
+            .arg(key)
+            .arg("initial")
+            .query(&mut conn)
+            .unwrap();
+        let _: () = redis::cmd("EXPIRE")
+            .arg(key)
+            .arg(120)
+            .query(&mut conn)
+            .unwrap();
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE ttl_str_persist (value text, ttl bigint) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+
+        // Update with TTL = -1 to persist
+        Spi::run("UPDATE ttl_str_persist SET value = 'updated', ttl = -1;").unwrap();
+
+        let ttl: i64 = redis::cmd("TTL").arg(key).query(&mut conn).unwrap();
+        assert_eq!(ttl, -1, "Expected persistent key (TTL -1), got {}", ttl);
+
+        Spi::run("DROP FOREIGN TABLE ttl_str_persist;").unwrap();
+        cleanup_redis_key(key);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_ttl_read_in_select() {
+        setup_fdw();
+        let key = "ttl_test:string:read";
+        cleanup_redis_key(key);
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let _: () = redis::cmd("SET")
+            .arg(key)
+            .arg("readtest")
+            .query(&mut conn)
+            .unwrap();
+        let _: () = redis::cmd("EXPIRE")
+            .arg(key)
+            .arg(500)
+            .query(&mut conn)
+            .unwrap();
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE ttl_str_read (value text, ttl bigint) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+
+        let ttl_val = Spi::get_one::<String>("SELECT ttl::text FROM ttl_str_read;").unwrap();
+        let ttl: i64 = ttl_val.unwrap().parse().unwrap();
+        assert!(
+            ttl > 0 && ttl <= 500,
+            "Expected TTL in range 1-500, got {}",
+            ttl
+        );
+
+        Spi::run("DROP FOREIGN TABLE ttl_str_read;").unwrap();
+        cleanup_redis_key(key);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_ttl_default_hash_table() {
+        setup_fdw();
+        let key = "ttl_test:hash:default";
+        cleanup_redis_key(key);
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE ttl_hash_default (field text, value text) SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}', ttl '120'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+
+        Spi::run("INSERT INTO ttl_hash_default VALUES ('myfield', 'myvalue');").unwrap();
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let ttl: i64 = redis::cmd("TTL").arg(key).query(&mut conn).unwrap();
+        assert!(ttl > 0 && ttl <= 120, "Expected TTL 1-120, got {}", ttl);
+
+        Spi::run("DROP FOREIGN TABLE ttl_hash_default;").unwrap();
+        cleanup_redis_key(key);
+        cleanup();
+    }
+
+    #[pg_test]
+    fn test_ttl_no_default_no_column_stays_persistent() {
+        setup_fdw();
+        let key = "ttl_test:string:no_ttl";
+        cleanup_redis_key(key);
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE ttl_str_no_ttl (value text) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+
+        Spi::run("INSERT INTO ttl_str_no_ttl VALUES ('persist_forever');").unwrap();
+
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let ttl: i64 = redis::cmd("TTL").arg(key).query(&mut conn).unwrap();
+        assert_eq!(ttl, -1, "Expected no TTL (-1), got {}", ttl);
+
+        Spi::run("DROP FOREIGN TABLE ttl_str_no_ttl;").unwrap();
+        cleanup_redis_key(key);
+        cleanup();
+    }
+}

--- a/src/tests/validation_tests.rs
+++ b/src/tests/validation_tests.rs
@@ -1,0 +1,179 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    const FDW_NAME: &str = "redis_validation_fdw";
+    const SERVER_NAME: &str = "redis_validation_server";
+
+    fn setup_fdw() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {} HANDLER redis_fdw_handler VALIDATOR redis_fdw_validator;",
+            FDW_NAME
+        ))
+        .unwrap();
+    }
+
+    fn cleanup() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+    }
+
+    fn setup_fdw_with_server() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '127.0.0.1:8899');",
+            SERVER_NAME, FDW_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "missing required option \"host_port\"")]
+    fn test_validator_rejects_missing_host_port() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {};",
+            SERVER_NAME, FDW_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "host_port must be in format")]
+    fn test_validator_rejects_invalid_host_port() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port 'no-port');",
+            SERVER_NAME, FDW_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    fn test_validator_accepts_valid_server_options() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '127.0.0.1:6379');",
+            SERVER_NAME, FDW_NAME
+        ))
+        .unwrap();
+        cleanup();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "cluster_mode must be")]
+    fn test_validator_rejects_invalid_cluster_mode() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '127.0.0.1:6379', cluster_mode 'yes');",
+            SERVER_NAME, FDW_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    fn test_validator_accepts_cluster_mode_true() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '127.0.0.1:6379', cluster_mode 'true');",
+            SERVER_NAME, FDW_NAME
+        ))
+        .unwrap();
+        cleanup();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "missing required option \"table_type\"")]
+    fn test_validator_rejects_missing_table_type() {
+        setup_fdw_with_server();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE val_test_tbl (val text) SERVER {} OPTIONS (table_key_prefix 'test:');",
+            SERVER_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "invalid table_type")]
+    fn test_validator_rejects_invalid_table_type() {
+        setup_fdw_with_server();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE val_test_tbl2 (val text) SERVER {} OPTIONS (table_type 'invalid', table_key_prefix 'test:');",
+            SERVER_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "missing required option \"table_key_prefix\"")]
+    fn test_validator_rejects_missing_key_prefix() {
+        setup_fdw_with_server();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE val_test_tbl3 (val text) SERVER {} OPTIONS (table_type 'string');",
+            SERVER_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "database must be an integer between 0 and 15")]
+    fn test_validator_rejects_invalid_database() {
+        setup_fdw_with_server();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE val_test_tbl4 (val text) SERVER {} OPTIONS (table_type 'string', table_key_prefix 'test:', database '99');",
+            SERVER_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "ttl must be a positive integer or -1")]
+    fn test_validator_rejects_invalid_ttl() {
+        setup_fdw_with_server();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE val_test_tbl5 (val text) SERVER {} OPTIONS (table_type 'string', table_key_prefix 'test:', ttl '0');",
+            SERVER_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    fn test_validator_accepts_valid_ttl() {
+        setup_fdw_with_server();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE val_test_tbl6 (val text) SERVER {} OPTIONS (table_type 'string', table_key_prefix 'test:', ttl '3600');",
+            SERVER_NAME
+        ))
+        .unwrap();
+        cleanup();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "batch_size must be between 100 and 100000")]
+    fn test_validator_rejects_invalid_batch_size() {
+        setup_fdw_with_server();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE val_test_tbl7 (val text) SERVER {} OPTIONS (table_type 'string', table_key_prefix 'test:', batch_size '50');",
+            SERVER_NAME
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    fn test_validator_accepts_valid_table_options() {
+        setup_fdw_with_server();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE val_test_tbl8 (field text, value text) SERVER {} OPTIONS (table_type 'hash', table_key_prefix 'test:', database '15', ttl '300', batch_size '5000');",
+            SERVER_NAME
+        ))
+        .unwrap();
+        cleanup();
+    }
+}


### PR DESCRIPTION
* feat: add FDW option validator with validation rules and unit tests
* feat: add TTL fields and apply/read TTL methods to FDW state
* feat: integrate TTL column detection, stripping, and population in FDW handlers
* feat: add multi-key pattern iteration in state manager
* feat: integrate multi-key mode in INSERT/DELETE handlers and data_len
  - INSERT routes to specific Redis key (first column) in multi-key mode
  - DELETE uses DEL on the full Redis key in multi-key mode
  - data_len() returns filtered_data.len() / cols_per_row in multi-key mode feat: fix FDW validator to use text[] SQL type and add integration tests
  - Rewrite validator as raw C function with pg_finfo for correct PG lookup
  - Parse options from text[] array (key=value format) passed by PostgreSQL