### PR TITLE
feat/tls-ssl-support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 - TTL support: table-level default + per-row override via virtual `ttl` column
 - Multi-key pattern queries: glob patterns in `table_key_prefix` for scanning multiple keys
 - DDL-time option validation via `redis_fdw_validator`
+- TLS/SSL support: `rediss://` URI scheme for encrypted connections (rustls backend)
 - UPDATE support implemented for all types (except Stream)
 - Cost estimation for query planner (`src/query/cost_estimation.rs`)
 - Connection pooling via R2D2 with global pool manager
@@ -96,7 +97,7 @@ FDW Callbacks (handlers.rs)
 | Crate | Version | Purpose |
 |-------|---------|---------|
 | pgrx | =0.18.0 | PostgreSQL extension framework |
-| redis | 1.2.1 | Redis client (with cluster, streams, r2d2 features) |
+| redis | 1.2.1 | Redis client (with cluster, streams, r2d2, tls-rustls features) |
 | r2d2 | 0.8.10 | Connection pooling |
 | thiserror | 2.0.12 | Error types |
 | rand | 0.9.2 | Random generation utilities |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,13 @@ Stream is append-only; UPDATE returns an error at the trait level and `IsForeign
 - Validates server options (host_port required, cluster_mode boolean)
 - Validates table options (table_type, table_key_prefix required; database 0-15; ttl; batch_size 100-100000)
 
+### TLS/SSL Support
+- Controlled via URI scheme in `host_port`: `rediss://` enables TLS, `#insecure` fragment skips cert verification
+- Uses rustls backend via redis crate features (`tls-rustls`, `tls-rustls-insecure`)
+- `build_redis_url()` in pool_manager.rs preserves `rediss://` scheme and `#insecure` fragment
+- `apply_to_url()` in auth/mod.rs handles both `redis://` and `rediss://` schemes
+- Validator's `is_valid_host_port()` strips scheme and fragment before checking host:port format
+
 ## Code Conventions
 
 - Use `pgrx::error!()` for PostgreSQL-level errors (never `panic!`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = "=0.18.0"
-redis = { version = "1.2.1", features = ["cluster", "streams","r2d2"] }
+redis = { version = "1.2.1", features = ["cluster", "streams", "r2d2", "tls-rustls", "tls-rustls-insecure"] }
 thiserror = "2.0.18"
 rand = "0.10.1"
 r2d2 = "0.8.10"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A high-performance Redis Foreign Data Wrapper (FDW) for PostgreSQL written in Ru
 
 - **High-performance data access** from Redis to PostgreSQL
 - **Redis Cluster support** with automatic failover and sharding across multiple nodes
+- **TLS/SSL support** via `rediss://` URI scheme with rustls backend (no OpenSSL dependency)
 - **Connection pooling** with R2D2 for efficient connection reuse and resource management
 - **WHERE clause pushdown optimization** for significantly improved query performance
 - **Redis data types support**: Hash, List, Set, ZSet, String, and Stream (with varying levels of implementation)
@@ -19,7 +20,7 @@ A high-performance Redis Foreign Data Wrapper (FDW) for PostgreSQL written in Ru
 - **Built with Rust** for memory safety and performance
 - **Unified trait interface** providing consistent behavior across all Redis table types
 - **Enhanced error handling** for robust foreign data operations
-- **Compatible with PostgreSQL 14-17**
+- **Compatible with PostgreSQL 14-18**
 
 ## Prerequisites
 
@@ -334,6 +335,47 @@ INSERT INTO user_sessions VALUES ('user123', 'session_token_abc');
 SELECT * FROM user_sessions WHERE field = 'user123';
 ```
 
+### 4. TLS/SSL Encrypted Connections
+
+Redis FDW supports TLS/SSL connections using the `rediss://` URI scheme. This is required for cloud Redis services (AWS ElastiCache, Azure Cache for Redis, GCP Memorystore) and any Redis deployment with TLS enabled.
+
+```sql
+-- TLS with certificate verification (production)
+CREATE SERVER redis_secure 
+FOREIGN DATA WRAPPER redis_wrapper
+OPTIONS (host_port 'rediss://redis.cloud.example.com:6380');
+
+-- TLS without certificate verification (dev/staging with self-signed certs)
+CREATE SERVER redis_dev 
+FOREIGN DATA WRAPPER redis_wrapper
+OPTIONS (host_port 'rediss://redis-dev.internal:6380/#insecure');
+
+-- Cluster with TLS
+CREATE SERVER redis_cluster_tls 
+FOREIGN DATA WRAPPER redis_wrapper
+OPTIONS (host_port 'rediss://node1:6380,rediss://node2:6380,rediss://node3:6380');
+
+-- TLS + Authentication
+CREATE SERVER redis_auth_tls 
+FOREIGN DATA WRAPPER redis_wrapper
+OPTIONS (host_port 'rediss://redis.cloud.example.com:6380');
+CREATE USER MAPPING FOR CURRENT_USER SERVER redis_auth_tls
+  OPTIONS (username 'default', password 'secret');
+```
+
+**Connection Schemes:**
+| Scheme | Behavior |
+|--------|----------|
+| `host:port` | Plaintext TCP connection |
+| `redis://host:port` | Plaintext TCP connection (explicit) |
+| `rediss://host:port` | TLS with certificate verification |
+| `rediss://host:port/#insecure` | TLS without certificate verification |
+
+**Notes:**
+- TLS uses the **rustls** backend (pure Rust, no OpenSSL dependency)
+- The `#insecure` fragment should only be used for development with self-signed certificates
+- All connection modes (single, cluster) support TLS
+
 ## Supported Redis Data Types (Usage Examples)
 
 ### TTL Support
@@ -539,7 +581,7 @@ SELECT * FROM redis_stream LIMIT 1000;
 ## Configuration Options
 
 ### Server Options
-- `host_port`: Redis connection string (format: `host:port`) - **Required**
+- `host_port`: Redis connection string (format: `host:port`, `redis://host:port`, or `rediss://host:port` for TLS) - **Required**
 
 ### Table Options
 - `database`: Redis database number (default: 0) - **Optional**
@@ -1039,5 +1081,6 @@ This project is licensed under the terms specified in the LICENSE file.
 ## Dependencies
 
 - **pgrx**: PostgreSQL extension framework for Rust
-- **redis**: Redis client library for Rust with integrated R2D2 connection pooling support
+- **redis**: Redis client library for Rust with integrated R2D2 connection pooling and TLS support
 - **r2d2**: Generic connection pool library providing efficient connection management and reuse
+- **rustls**: TLS implementation (pulled in via redis crate's `tls-rustls` feature)

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -47,26 +47,25 @@ impl RedisAuthConfig {
 
         let auth_component = self.get_auth_url_component();
 
-        // Handle different URL formats
-        if url.starts_with("redis://") {
-            // Remove existing auth if present
-            let url_without_auth = if let Some(at_pos) = url.find('@') {
-                // Check if there's a scheme before @ to distinguish auth from domain
-                if url[7..at_pos].contains(':') {
-                    format!("redis://{}", &url[at_pos + 1..])
-                } else {
-                    url.to_string()
-                }
-            } else {
-                url.to_string()
-            };
-
-            // Insert auth component
-            format!("redis://{}{}", auth_component, &url_without_auth[8..])
+        // Detect scheme case-insensitively (RFC 3986), but preserve original casing
+        let url_lower = url.to_ascii_lowercase();
+        let (scheme, rest) = if url_lower.starts_with("rediss://") {
+            (&url[..9], &url[9..])
+        } else if url_lower.starts_with("redis://") {
+            (&url[..8], &url[8..])
         } else {
-            // For non-redis:// URLs, prepend redis:// with auth
-            format!("redis://{}{}", auth_component, url)
-        }
+            return format!("redis://{}{}", auth_component, url);
+        };
+
+        // Remove existing auth if present (only look in the authority component, not path/query/fragment)
+        let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+        let cleaned = if let Some(at_pos) = authority.rfind('@') {
+            &rest[at_pos + 1..]
+        } else {
+            rest
+        };
+
+        format!("{}{}{}", scheme, auth_component, cleaned)
     }
 
     /// Generate a cache key for pool identification
@@ -197,5 +196,100 @@ mod tests {
             username: Some("admin".to_string()),
         };
         assert_eq!(full_auth.cache_key(), "auth:user:admin");
+    }
+
+    #[test]
+    fn test_apply_to_url_rediss_no_auth() {
+        let config = RedisAuthConfig::default();
+        let url = "rediss://redis.cloud.com:6380/0";
+        assert_eq!(config.apply_to_url(url), url);
+    }
+
+    #[test]
+    fn test_apply_to_url_rediss_with_password() {
+        let config = RedisAuthConfig {
+            password: Some("secret".to_string()),
+            username: None,
+        };
+        assert_eq!(
+            config.apply_to_url("rediss://redis.cloud.com:6380/0"),
+            "rediss://:secret@redis.cloud.com:6380/0"
+        );
+    }
+
+    #[test]
+    fn test_apply_to_url_rediss_with_username_password() {
+        let config = RedisAuthConfig {
+            password: Some("pass".to_string()),
+            username: Some("user".to_string()),
+        };
+        assert_eq!(
+            config.apply_to_url("rediss://redis.cloud.com:6380/0"),
+            "rediss://user:pass@redis.cloud.com:6380/0"
+        );
+    }
+
+    #[test]
+    fn test_apply_to_url_rediss_replace_existing_auth() {
+        let config = RedisAuthConfig {
+            password: Some("new_pass".to_string()),
+            username: Some("new_user".to_string()),
+        };
+        assert_eq!(
+            config.apply_to_url("rediss://old:old@redis.cloud.com:6380/0"),
+            "rediss://new_user:new_pass@redis.cloud.com:6380/0"
+        );
+    }
+
+    #[test]
+    fn test_apply_to_url_replace_password_only_auth() {
+        let config = RedisAuthConfig {
+            password: Some("new_pass".to_string()),
+            username: Some("new_user".to_string()),
+        };
+        assert_eq!(
+            config.apply_to_url("redis://password@127.0.0.1:6379/0"),
+            "redis://new_user:new_pass@127.0.0.1:6379/0"
+        );
+    }
+
+    #[test]
+    fn test_apply_to_url_no_false_positive_at_in_path() {
+        let config = RedisAuthConfig {
+            password: Some("secret".to_string()),
+            username: None,
+        };
+        assert_eq!(
+            config.apply_to_url("redis://127.0.0.1:6379/0"),
+            "redis://:secret@127.0.0.1:6379/0"
+        );
+    }
+
+    #[test]
+    fn test_apply_to_url_replace_password_with_at_sign() {
+        let config = RedisAuthConfig {
+            password: Some("new_pass".to_string()),
+            username: Some("new_user".to_string()),
+        };
+        assert_eq!(
+            config.apply_to_url("redis://user:p%40ss@127.0.0.1:6379/0"),
+            "redis://new_user:new_pass@127.0.0.1:6379/0"
+        );
+    }
+
+    #[test]
+    fn test_apply_to_url_case_insensitive_scheme() {
+        let config = RedisAuthConfig {
+            password: Some("secret".to_string()),
+            username: None,
+        };
+        assert_eq!(
+            config.apply_to_url("REDISS://host:6380/0"),
+            "REDISS://:secret@host:6380/0"
+        );
+        assert_eq!(
+            config.apply_to_url("Redis://host:6379/0"),
+            "Redis://:secret@host:6379/0"
+        );
     }
 }

--- a/src/core/pool_manager.rs
+++ b/src/core/pool_manager.rs
@@ -128,12 +128,27 @@ pub enum PoolError {
 
 /// Build a Redis URL from host:port with optional database and auth
 fn build_redis_url(host_port: &str, database: i64, auth_config: &RedisAuthConfig) -> String {
-    let base_url = if host_port.starts_with("redis://") {
-        format!("{}/{}", host_port, database)
-    } else {
-        format!("redis://{}/{}", host_port, database)
+    let host_port = host_port.trim();
+    // Separate the fragment (#insecure) from the host if present
+    let (host_part, fragment) = match host_port.split_once('#') {
+        Some((h, f)) => (h.trim_end_matches('/'), Some(f)),
+        None => (host_port.trim_end_matches('/'), None),
     };
-    auth_config.apply_to_url(&base_url)
+
+    let host_part_lower = host_part.to_ascii_lowercase();
+    let base_url =
+        if host_part_lower.starts_with("rediss://") || host_part_lower.starts_with("redis://") {
+            format!("{}/{}", host_part, database)
+        } else {
+            format!("redis://{}/{}", host_part, database)
+        };
+
+    let url = auth_config.apply_to_url(&base_url);
+
+    match fragment {
+        Some(frag) => format!("{}#{}", url, frag),
+        None => url,
+    }
 }
 
 /// Build URLs for cluster nodes
@@ -752,5 +767,85 @@ mod tests {
 
         let err = PoolError::LockPoisoned;
         assert!(err.to_string().contains("poisoned"));
+    }
+
+    // --------------------------------
+    // TLS URL Building Tests
+    // --------------------------------
+
+    #[test]
+    fn test_build_redis_url_with_rediss_scheme() {
+        let auth = RedisAuthConfig::default();
+        let url = build_redis_url("rediss://redis.example.com:6380", 0, &auth);
+        assert_eq!(url, "rediss://redis.example.com:6380/0");
+    }
+
+    #[test]
+    fn test_build_redis_url_with_rediss_insecure() {
+        let auth = RedisAuthConfig::default();
+        let url = build_redis_url("rediss://redis-dev.internal:6380/#insecure", 0, &auth);
+        assert_eq!(url, "rediss://redis-dev.internal:6380/0#insecure");
+    }
+
+    #[test]
+    fn test_build_redis_url_plain_host_unchanged() {
+        let auth = RedisAuthConfig::default();
+        let url = build_redis_url("127.0.0.1:6379", 0, &auth);
+        assert_eq!(url, "redis://127.0.0.1:6379/0");
+    }
+
+    #[test]
+    fn test_build_redis_url_rediss_with_auth() {
+        let auth = RedisAuthConfig {
+            password: Some("secret".to_string()),
+            username: None,
+        };
+        let url = build_redis_url("rediss://redis.cloud.com:6380", 3, &auth);
+        assert!(url.starts_with("rediss://"));
+        assert!(url.contains(":secret@"));
+        assert!(url.ends_with("/3"));
+    }
+
+    #[test]
+    fn test_build_redis_url_rediss_insecure_with_database() {
+        let auth = RedisAuthConfig::default();
+        let url = build_redis_url("rediss://host:6380/#insecure", 5, &auth);
+        assert_eq!(url, "rediss://host:6380/5#insecure");
+    }
+
+    #[test]
+    fn test_build_cluster_urls_with_rediss() {
+        let auth = RedisAuthConfig::default();
+        let urls = build_cluster_urls(
+            "rediss://node1:6380,rediss://node2:6380,rediss://node3:6380",
+            0,
+            &auth,
+        )
+        .unwrap();
+        assert_eq!(urls.len(), 3);
+        assert_eq!(urls[0], "rediss://node1:6380/0");
+        assert_eq!(urls[1], "rediss://node2:6380/0");
+        assert_eq!(urls[2], "rediss://node3:6380/0");
+    }
+
+    #[test]
+    fn test_build_redis_url_trailing_slash_no_fragment() {
+        let auth = RedisAuthConfig::default();
+        let url = build_redis_url("rediss://host:6380/", 0, &auth);
+        assert_eq!(url, "rediss://host:6380/0");
+    }
+
+    #[test]
+    fn test_build_redis_url_case_insensitive_scheme() {
+        let auth = RedisAuthConfig::default();
+        let url = build_redis_url("REDISS://host:6380", 0, &auth);
+        assert_eq!(url, "REDISS://host:6380/0");
+    }
+
+    #[test]
+    fn test_build_redis_url_whitespace_trimmed() {
+        let auth = RedisAuthConfig::default();
+        let url = build_redis_url("  redis://host:6379  ", 0, &auth);
+        assert_eq!(url, "redis://host:6379/0");
     }
 }

--- a/src/core/validator.rs
+++ b/src/core/validator.rs
@@ -183,7 +183,38 @@ pub mod validation_rules {
     }
 
     pub fn is_valid_host_port(s: &str) -> bool {
-        !s.is_empty() && s.contains(':')
+        if s.is_empty() {
+            return false;
+        }
+        s.split(',').all(|node| {
+            let node = node.trim();
+            if node.is_empty() {
+                return false;
+            }
+            // Strip scheme case-insensitively (RFC 3986)
+            let node_lower = node.to_ascii_lowercase();
+            let without_scheme = if node_lower.starts_with("rediss://") {
+                &node[9..]
+            } else if node_lower.starts_with("redis://") {
+                &node[8..]
+            } else {
+                node
+            };
+            // Strip fragment (#insecure) if present
+            let without_fragment = without_scheme.split('#').next().unwrap_or(without_scheme);
+            // Ensure no path segments are present in the host:port part
+            let authority = without_fragment.trim_end_matches('/');
+            if authority.is_empty() || authority.contains('/') {
+                return false;
+            }
+            // Must have host:port format with numeric port
+            match authority.rfind(':') {
+                Some(pos) if pos > 0 && pos < authority.len() - 1 => {
+                    authority[pos + 1..].parse::<u16>().is_ok()
+                }
+                _ => false,
+            }
+        })
     }
 }
 
@@ -241,5 +272,54 @@ mod tests {
         assert!(is_valid_host_port("redis.example.com:6379"));
         assert!(!is_valid_host_port(""));
         assert!(!is_valid_host_port("no-port"));
+    }
+
+    #[test]
+    fn test_valid_host_port_rediss_scheme() {
+        assert!(is_valid_host_port("rediss://redis.example.com:6380"));
+        assert!(is_valid_host_port("rediss://127.0.0.1:6380"));
+        assert!(is_valid_host_port("rediss://host:6380/#insecure"));
+        assert!(is_valid_host_port("redis://127.0.0.1:6379"));
+    }
+
+    #[test]
+    fn test_valid_host_port_rediss_invalid() {
+        assert!(!is_valid_host_port("rediss://"));
+        assert!(!is_valid_host_port("rediss://no-port"));
+    }
+
+    #[test]
+    fn test_valid_host_port_cluster_string() {
+        assert!(is_valid_host_port("node1:6379,node2:6379,node3:6379"));
+        assert!(is_valid_host_port(
+            "rediss://node1:6380,rediss://node2:6380,rediss://node3:6380"
+        ));
+        assert!(!is_valid_host_port("node1:6379,node2"));
+        assert!(!is_valid_host_port("node1:6379,,node3:6379"));
+    }
+
+    #[test]
+    fn test_valid_host_port_rejects_path_segments() {
+        assert!(!is_valid_host_port("redis://host:6379/extra/path"));
+        assert!(!is_valid_host_port("rediss://host:6380/db/path"));
+    }
+
+    #[test]
+    fn test_valid_host_port_case_insensitive_scheme() {
+        assert!(is_valid_host_port("REDISS://host:6380"));
+        assert!(is_valid_host_port("Redis://host:6379"));
+        assert!(is_valid_host_port("REDIS://host:6379"));
+    }
+
+    #[test]
+    fn test_valid_host_port_rejects_ipv6_without_port() {
+        assert!(!is_valid_host_port("[::1]"));
+        assert!(!is_valid_host_port("redis://[::1]"));
+    }
+
+    #[test]
+    fn test_valid_host_port_rejects_non_numeric_port() {
+        assert!(!is_valid_host_port("host:abc"));
+        assert!(!is_valid_host_port("redis://host:notaport"));
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -52,3 +52,6 @@ pub mod ttl_tests;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub mod multi_key_tests;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod tls_tests;

--- a/src/tests/tls_tests.rs
+++ b/src/tests/tls_tests.rs
@@ -1,0 +1,49 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    fn run_validator_test(test_name: &str, host_port: &str) {
+        let fdw_name = format!("redis_tls_fdw_{}", test_name);
+        let server_name = format!("redis_tls_server_{}", test_name);
+
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            fdw_name
+        ));
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {} HANDLER redis_fdw_handler VALIDATOR redis_fdw_validator;",
+            fdw_name
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '{}');",
+            server_name, fdw_name, host_port
+        ))
+        .unwrap();
+
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            fdw_name
+        ));
+    }
+
+    #[pg_test]
+    fn test_validator_accepts_rediss_scheme() {
+        run_validator_test("rediss_scheme", "rediss://redis.example.com:6380");
+    }
+
+    #[pg_test]
+    fn test_validator_accepts_rediss_insecure() {
+        run_validator_test(
+            "rediss_insecure",
+            "rediss://redis-dev.internal:6380/#insecure",
+        );
+    }
+
+    #[pg_test]
+    fn test_validator_accepts_rediss_cluster() {
+        run_validator_test("rediss_cluster", "rediss://node1:6380,rediss://node2:6380");
+    }
+}


### PR DESCRIPTION
Defines the design for adding TLS/SSL support to redis_fdw_rs using rustls backend. Covers server options (tls, tls_insecure), URL scheme rewriting (redis:// → rediss://), and validator updates.

feat: add tls-rustls feature flags to redis dependency
feat: add TLS/SSL connection support via rediss:// URI scheme

- Preserve rediss:// scheme in build_redis_url() and build_cluster_urls()
- Handle #insecure fragment for skipping certificate verification
- Update apply_to_url() to support rediss:// scheme with auth
- Update is_valid_host_port() to accept rediss:// and #insecure
- Add unit tests for all TLS URL building, auth, and validation
- Add pg_test integration tests for validator acceptance
- Update README.md, CLAUDE.md, AGENTS.md with TLS documentation