### PR TITLE
feat/rich-fdw-lifecycle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show
+          rustc --version
+          cargo --version
+
       - name: Cache cargo dependencies
         uses: actions/cache@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,19 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 
 ## Current State
 
-**Feature-complete for all CRUD operations.** All Redis types (String, Hash, List, Set, ZSet) support SELECT, INSERT, UPDATE, DELETE. Stream supports SELECT, INSERT, DELETE only (append-only by design).
+**Feature-complete for all CRUD operations plus EXPLAIN, batch INSERT, TRUNCATE, IMPORT FOREIGN SCHEMA, ANALYZE, and COPY FROM.** All Redis types (String, Hash, List, Set, ZSet) support SELECT, INSERT, UPDATE, DELETE, TRUNCATE. Stream supports SELECT, INSERT, DELETE, TRUNCATE only (append-only by design).
 
 ### Recent Work
+- FDW lifecycle refactoring: batch insert logic moved to `state_manager.batch_insert_data()`; handlers is now a thin dispatch layer
+- ANALYZE support: `analyze_foreign_table` + `acquire_sample_rows` for query planning statistics
+- COPY FROM / INSERT SELECT: `begin_foreign_insert` / `end_foreign_insert` callbacks
+- ShutdownForeignScan: early connection release back to R2D2 pool for better concurrency
+- RecheckForeignScan: correctness for join rechecks (returns true unconditionally)
+- EXPLAIN support: `explain_foreign_scan` and `explain_foreign_modify` callbacks with server, key, type, pushdown, batch info
+- Batch INSERT: `exec_foreign_batch_insert` with pipelined Redis commands and configurable `batch_size`
+- TRUNCATE: `exec_foreign_truncate` using UNLINK (single-key) or SCAN+UNLINK (multi-key patterns)
+- IMPORT FOREIGN SCHEMA: `import_foreign_schema` auto-discovers keys, groups by prefix, generates DDL
+- OOM robustness: soft limits with warnings for large datasets (100K per-key, 1M total), pool saturation cap (64 pools)
 - TTL support: table-level default + per-row override via virtual `ttl` column
 - Multi-key pattern queries: glob patterns in `table_key_prefix` for scanning multiple keys
 - DDL-time option validation via `redis_fdw_validator`
@@ -22,7 +32,7 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 
 ### Known Issues
 - Cluster integration tests (9 tests) fail without Redis Cluster infrastructure running
-- All non-cluster tests pass (187/187)
+- All non-cluster tests pass (331/331)
 
 ## How to Work on This Project
 
@@ -73,11 +83,29 @@ FDW Callbacks (handlers.rs)
     ├── Planning: get_foreign_rel_size → get_foreign_paths → get_foreign_plan
     │       └── cost_estimation.rs, pushdown.rs
     │
-    ├── Scanning: begin_foreign_scan → iterate_foreign_scan → end_foreign_scan
+    ├── Scanning: begin_foreign_scan → iterate → recheck → shutdown → end_foreign_scan
     │       └── state_manager.rs → RedisTableType dispatch → implementations/*
     │
-    └── Modify: begin_foreign_modify → exec_foreign_{insert,update,delete}
-            └── state_manager.rs → RedisTableType dispatch → implementations/*
+    ├── Explain: explain_foreign_scan, explain_foreign_modify
+    │       └── Reports server, key, type, pushdown, batch size, rows fetched
+    │
+    ├── Modify: begin_foreign_modify → exec_foreign_{insert,update,delete}
+    │       └── state_manager.rs → RedisTableType dispatch → implementations/*
+    │
+    ├── COPY FROM / INSERT SELECT: begin_foreign_insert → exec_foreign_insert → end_foreign_insert
+    │       └── Standalone state init for bulk insert paths
+    │
+    ├── Batch Insert: get_foreign_modify_batch_size → exec_foreign_batch_insert
+    │       └── state_manager.batch_insert_data() — pipelines rows into Redis
+    │
+    ├── Truncate: exec_foreign_truncate
+    │       └── UNLINK (single-key) or SCAN+UNLINK (multi-key pattern)
+    │
+    ├── Import Schema: import_foreign_schema
+    │       └── SCAN → TYPE pipeline → group by prefix → generate DDL
+    │
+    └── Analyze: analyze_foreign_table → acquire_sample_rows
+            └── Enables ANALYZE for query planning (HLEN/SCARD/ZCARD/XLEN + sampling)
                     │
                     ▼
               Redis (via R2D2 pool_manager.rs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,17 @@ cargo fmt
 
 ### FDW Lifecycle (PostgreSQL callbacks)
 1. **Planning**: `get_foreign_rel_size` → `get_foreign_paths` → `get_foreign_plan`
-2. **Scanning**: `begin_foreign_scan` → `iterate_foreign_scan` → `end_foreign_scan`
-3. **Modify**: `plan_foreign_modify` → `begin_foreign_modify` → `exec_foreign_insert`/`update`/`delete` → `end_foreign_modify`
-4. **Updatability**: `is_foreign_rel_updatable` (bitmask: 28 for all types, 24 for stream)
+2. **Scanning**: `begin_foreign_scan` → `iterate_foreign_scan` → `re_scan_foreign_scan` → `end_foreign_scan`
+   - `recheck_foreign_scan` (returns true; no lossy filtering)
+   - `shutdown_foreign_scan` (early connection release back to pool)
+3. **Explain**: `explain_foreign_scan`, `explain_foreign_modify` (EXPLAIN output with server, key, type, pushdown, batch info)
+4. **Modify**: `plan_foreign_modify` → `begin_foreign_modify` → `exec_foreign_insert`/`update`/`delete` → `end_foreign_modify`
+5. **Batch Insert**: `get_foreign_modify_batch_size` → `exec_foreign_batch_insert` (pipelined multi-row)
+6. **COPY FROM / INSERT SELECT**: `begin_foreign_insert` → (reuses `exec_foreign_insert`) → `end_foreign_insert`
+7. **Truncate**: `exec_foreign_truncate` (UNLINK for single-key; SCAN+UNLINK for patterns)
+8. **Import Schema**: `import_foreign_schema` (SCAN → TYPE → group by prefix → generate DDL)
+9. **Analyze**: `analyze_foreign_table` → `acquire_sample_rows` (enables `ANALYZE` for query planning)
+10. **Updatability**: `is_foreign_rel_updatable` (bitmask: 28 for all types, 24 for stream)
 
 ### Trait Pattern
 All Redis types implement `RedisTableOperations` (in `src/tables/interface.rs`):
@@ -60,14 +68,14 @@ Dispatch from `RedisTableType` enum uses macros in `src/tables/macros.rs`.
 
 ### Supported Operations
 
-| Type    | SELECT | INSERT | UPDATE | DELETE |
-|---------|--------|--------|--------|--------|
-| String  | ✅     | ✅     | ✅     | ✅     |
-| Hash    | ✅     | ✅     | ✅     | ✅     |
-| List    | ✅     | ✅     | ✅     | ✅     |
-| Set     | ✅     | ✅     | ✅     | ✅     |
-| ZSet    | ✅     | ✅     | ✅     | ✅     |
-| Stream  | ✅     | ✅     | ❌     | ✅     |
+| Type    | SELECT | INSERT | UPDATE | DELETE | TRUNCATE |
+|---------|--------|--------|--------|--------|----------|
+| String  | ✅     | ✅     | ✅     | ✅     | ✅       |
+| Hash    | ✅     | ✅     | ✅     | ✅     | ✅       |
+| List    | ✅     | ✅     | ✅     | ✅     | ✅       |
+| Set     | ✅     | ✅     | ✅     | ✅     | ✅       |
+| ZSet    | ✅     | ✅     | ✅     | ✅     | ✅       |
+| Stream  | ✅     | ✅     | ❌     | ✅     | ✅       |
 
 Stream is append-only; UPDATE returns an error at the trait level and `IsForeignRelUpdatable` omits the UPDATE bit for stream tables.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Redis FDW Makefile
 
 .PHONY: help build build-release install test test-all test-unit \
-        clean format lint check setup-redis setup-cluster cleanup-redis redis-status \
+        clean format lint check setup-redis cleanup-redis redis-status \
         test-pg14 test-pg15 test-pg16 test-pg17 test-pg18 stop-pg before-git-push before-git-push-all
 
 # Default PG version for single-target commands
@@ -18,7 +18,6 @@ help:
 	@echo "  make test-unit       Run cargo check + clippy (no Redis required)"
 	@echo ""
 	@echo "  make setup-redis     Start Redis single-node + cluster"
-	@echo "  make setup-cluster   Alias for setup-redis (starts both)"
 	@echo "  make cleanup-redis   Stop and remove all Redis containers"
 	@echo "  make redis-status    Show running Redis containers"
 	@echo "  make stop-pg         Stop stale pgrx test PostgreSQL instance"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ A high-performance Redis Foreign Data Wrapper (FDW) for PostgreSQL written in Ru
 - **Multi-key patterns**: Glob patterns (`*`, `?`, `[`) in `table_key_prefix` to query multiple keys
 - **DDL validation**: Option validator checks all options at CREATE time
 - **Stream pagination**: Configurable batch processing for large data sets
+- **EXPLAIN support**: Detailed scan/modify metadata (server, key, pushdown, batch size)
+- **Batch INSERT**: Pipelined multi-row inserts via `ExecForeignBatchInsert` (configurable `batch_size`)
+- **TRUNCATE**: Single-key `UNLINK` or pattern-based `SCAN + UNLINK` for multi-key tables
+- **IMPORT FOREIGN SCHEMA**: Auto-discovers Redis keys, groups by prefix, and generates DDL
+- **ANALYZE**: Statistics gathering for query planner via type-specific cardinality commands
+- **COPY FROM**: Bulk loading via `COPY` and `INSERT INTO ... SELECT` into foreign tables
+- **OOM protection**: Soft limits with warnings for large datasets and connection pool saturation
 - **Compatible with PostgreSQL 14-18**
 
 ## Prerequisites
@@ -114,6 +121,15 @@ SELECT * FROM task_queue;
 | `zset` | member, score | ZADD, ZRANGE, ZREM | Yes |
 | `stream` | stream_id, field1, value1, ... | XADD, XRANGE, XDEL | No (append-only) |
 
+| Type    | SELECT | INSERT | UPDATE | DELETE | TRUNCATE |
+|---------|--------|--------|--------|--------|----------|
+| String  | ✅     | ✅     | ✅     | ✅     | ✅       |
+| Hash    | ✅     | ✅     | ✅     | ✅     | ✅       |
+| List    | ✅     | ✅     | ✅     | ✅     | ✅       |
+| Set     | ✅     | ✅     | ✅     | ✅     | ✅       |
+| ZSet    | ✅     | ✅     | ✅     | ✅     | ✅       |
+| Stream  | ✅     | ✅     | ❌     | ✅     | ✅       |
+
 ### Table Definitions
 
 ```sql
@@ -188,6 +204,7 @@ OPTIONS (
 | `table_key_prefix` | Yes | Redis key or glob pattern for multi-key mode |
 | `database` | No | Redis database number (0-15, default: 0) |
 | `ttl` | No | Default key expiration in seconds |
+| `batch_size` | No | Max rows per batch INSERT pipeline (100-100000, default: 5000) |
 
 ### Redis Cluster
 
@@ -273,6 +290,66 @@ DELETE FROM all_users WHERE key = 'user:2';
 | List | key, element |
 | Set | key, member |
 | ZSet | key, score, member |
+
+## EXPLAIN Support
+
+The FDW provides detailed information in `EXPLAIN` output for both scan and modify operations:
+
+```sql
+EXPLAIN (VERBOSE) SELECT * FROM user_profiles WHERE field = 'email';
+```
+
+## Batch INSERT
+
+Multi-row INSERT statements are automatically pipelined to Redis for better throughput. Configure with the `batch_size` table option:
+
+```sql
+CREATE FOREIGN TABLE cached_items (key text, value text)
+SERVER redis_server
+OPTIONS (table_type 'hash', table_key_prefix 'cache:items', batch_size '5000');
+
+-- All rows sent in a single Redis pipeline
+INSERT INTO cached_items VALUES ('a', '1'), ('b', '2'), ('c', '3'), ...;
+```
+
+## TRUNCATE
+
+`TRUNCATE` is supported for both single-key and multi-key pattern tables:
+
+```sql
+-- Single-key: UNLINKs the Redis key
+TRUNCATE user_profiles;
+
+-- Multi-key pattern: SCANs matching keys and UNLINKs them in batches
+CREATE FOREIGN TABLE all_sessions (key text, value text)
+SERVER redis_server OPTIONS (table_type 'string', table_key_prefix 'session:*');
+
+TRUNCATE all_sessions;  -- Removes all session:* keys
+```
+
+## IMPORT FOREIGN SCHEMA
+
+Auto-discover Redis keys and generate foreign table DDL:
+
+```sql
+-- Import all discovered tables
+IMPORT FOREIGN SCHEMA "public"
+FROM SERVER redis_server INTO my_schema;
+
+-- Import only specific tables (matched by derived prefix name)
+IMPORT FOREIGN SCHEMA "public" LIMIT TO (users, sessions)
+FROM SERVER redis_server INTO my_schema;
+
+-- Import all except specific tables
+IMPORT FOREIGN SCHEMA "public" EXCEPT (temp_data)
+FROM SERVER redis_server INTO my_schema;
+```
+
+The import process:
+1. SCANs Redis keys (up to 10,000 samples)
+2. TYPE-checks each key via pipeline
+3. Groups keys by prefix (splits on `:` delimiter)
+4. Generates `CREATE FOREIGN TABLE` DDL with appropriate columns per type
 
 ## Performance
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+components = ["rustfmt", "clippy"]

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -9,6 +9,7 @@ use pgrx::{
     prelude::*,
     PgMemoryContexts, PgRelation,
 };
+use std::ffi::CString;
 use std::ptr;
 
 #[inline]
@@ -55,7 +56,14 @@ pub extern "C" fn redis_fdw_handler() -> FdwRoutine {
         fdw_routine.IterateForeignScan = Some(iterate_foreign_scan);
         fdw_routine.ReScanForeignScan = Some(re_scan_foreign_scan);
         fdw_routine.EndForeignScan = Some(end_foreign_scan);
+        fdw_routine.RecheckForeignScan = Some(recheck_foreign_scan);
+        fdw_routine.ShutdownForeignScan = Some(shutdown_foreign_scan);
 
+        // explain
+        fdw_routine.ExplainForeignScan = Some(explain_foreign_scan);
+        fdw_routine.ExplainForeignModify = Some(explain_foreign_modify);
+
+        // modify
         fdw_routine.AddForeignUpdateTargets = Some(add_foreign_update_targets);
         fdw_routine.PlanForeignModify = Some(plan_foreign_modify);
         fdw_routine.BeginForeignModify = Some(begin_foreign_modify);
@@ -64,6 +72,23 @@ pub extern "C" fn redis_fdw_handler() -> FdwRoutine {
         fdw_routine.ExecForeignUpdate = Some(exec_foreign_update);
         fdw_routine.EndForeignModify = Some(end_foreign_modify);
         fdw_routine.IsForeignRelUpdatable = Some(is_foreign_rel_updatable);
+
+        // batch insert
+        fdw_routine.ExecForeignBatchInsert = Some(exec_foreign_batch_insert);
+        fdw_routine.GetForeignModifyBatchSize = Some(get_foreign_modify_batch_size);
+
+        // COPY FROM / INSERT SELECT support
+        fdw_routine.BeginForeignInsert = Some(begin_foreign_insert);
+        fdw_routine.EndForeignInsert = Some(end_foreign_insert);
+
+        // truncate
+        fdw_routine.ExecForeignTruncate = Some(exec_foreign_truncate);
+
+        // import schema
+        fdw_routine.ImportForeignSchema = Some(import_foreign_schema);
+
+        // analyze
+        fdw_routine.AnalyzeForeignTable = Some(analyze_foreign_table);
 
         fdw_routine
     }
@@ -276,6 +301,7 @@ unsafe extern "C-unwind" fn iterate_foreign_scan(
     node: *mut pgrx::pg_sys::ForeignScanState,
 ) -> *mut pgrx::pg_sys::TupleTableSlot {
     log!("---> iterate_foreign_scan");
+    pgrx::check_for_interrupts!();
     let state = state_from_ptr((*node).fdw_state);
     let slot = (*node).ss.ss_ScanTupleSlot;
     let tupdesc = (*slot).tts_tupleDescriptor;
@@ -401,6 +427,28 @@ extern "C-unwind" fn re_scan_foreign_scan(node: *mut pgrx::pg_sys::ForeignScanSt
         state.cached_ttl = None;
         state.multi_key_ttl_cache.clear();
         state.table_type.clear_data();
+    }
+}
+
+#[pg_guard]
+extern "C-unwind" fn recheck_foreign_scan(
+    _node: *mut pgrx::pg_sys::ForeignScanState,
+    _slot: *mut pgrx::pg_sys::TupleTableSlot,
+) -> bool {
+    log!("---> recheck_foreign_scan");
+    true
+}
+
+#[pg_guard]
+extern "C-unwind" fn shutdown_foreign_scan(node: *mut pgrx::pg_sys::ForeignScanState) {
+    log!("---> shutdown_foreign_scan");
+    unsafe {
+        let fdw_state = (*node).fdw_state as *mut RedisFdwState;
+        if fdw_state.is_null() {
+            return;
+        }
+        let state = &mut *fdw_state;
+        state.redis_connection = None;
     }
 }
 
@@ -647,15 +695,8 @@ unsafe extern "C-unwind" fn exec_foreign_delete(
             log!("Attempting to delete key: '{}'", key);
 
             if state.is_multi_key {
-                // Multi-key mode: DEL the entire Redis key
-                if let Some(conn) = state.redis_connection.as_mut() {
-                    let conn_like = conn.as_connection_like_mut();
-                    let result: Result<(), _> = redis::cmd("DEL").arg(&key).query(conn_like);
-                    if let Err(e) = result {
-                        error!("Failed to delete Redis key '{}': {:?}", key, e);
-                    }
-                } else {
-                    error!("Redis connection not available for delete");
+                if let Err(e) = state.delete_key(&key) {
+                    error!("Failed to delete Redis key '{}': {:?}", key, e);
                 }
             } else if let Err(e) = state.delete_data(std::slice::from_ref(&key)) {
                 error!("Failed to delete key '{}': {:?}", key, e);
@@ -691,6 +732,54 @@ unsafe extern "C-unwind" fn end_foreign_modify(
         if !ctx.is_null() {
             delete_wrappers_memctx(ctx);
         }
+    }
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn begin_foreign_insert(
+    _mtstate: *mut pgrx::pg_sys::ModifyTableState,
+    rinfo: *mut pgrx::pg_sys::ResultRelInfo,
+) {
+    log!("---> begin_foreign_insert");
+    let relation = (*rinfo).ri_RelationDesc;
+    let ftable_id = (*relation).rd_id;
+    let ctx_name = format!("Wrappers_insert_{}", ftable_id.to_u32());
+    let ctx = create_wrappers_memctx(&ctx_name);
+    let mut state = RedisFdwState::new(ctx);
+    PgMemoryContexts::For(state.tmp_ctx).switch_to(|_| {
+        let opts = get_foreign_table_options(ftable_id);
+        log!("Foreign table options for insert: {:?}", opts);
+        state.update_from_options(opts);
+
+        if let Err(e) = state.init_redis_connection_from_options() {
+            pgrx::error!("Failed to connect to Redis: {}", e);
+        }
+
+        state.set_table_type();
+    });
+
+    let tupdesc = (*relation).rd_att;
+    state.ttl_column_index = detect_ttl_column(tupdesc);
+
+    let state_ptr = PgMemoryContexts::For(ctx).leak_and_drop_on_delete(state);
+    (*rinfo).ri_FdwState = state_ptr as *mut std::os::raw::c_void;
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn end_foreign_insert(
+    _estate: *mut pgrx::pg_sys::EState,
+    rinfo: *mut pgrx::pg_sys::ResultRelInfo,
+) {
+    log!("---> end_foreign_insert");
+    let fdw_state = (*rinfo).ri_FdwState as *mut RedisFdwState;
+    if fdw_state.is_null() {
+        return;
+    }
+
+    let state = &*fdw_state;
+    let ctx = state.tmp_ctx;
+    if !ctx.is_null() {
+        delete_wrappers_memctx(ctx);
     }
 }
 
@@ -739,4 +828,752 @@ unsafe fn extract_delete_key(
         }
         None => Err("Failed to convert datum to string"),
     }
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn explain_foreign_scan(
+    node: *mut pg_sys::ForeignScanState,
+    es: *mut pg_sys::ExplainState,
+) {
+    log!("---> explain_foreign_scan");
+    let fdw_state = (*node).fdw_state as *mut RedisFdwState;
+    if fdw_state.is_null() {
+        return;
+    }
+    let state = &*fdw_state;
+
+    let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
+    let key_cstr = CString::new(state.table_key_prefix.as_str()).unwrap_or_default();
+    let type_name = state.table_type.redis_type_name();
+    let type_cstr = CString::new(type_name).unwrap_or_default();
+    let multi_key_cstr =
+        CString::new(if state.is_multi_key { "true" } else { "false" }).unwrap_or_default();
+
+    let label_server = c"Redis Server";
+    let label_key = c"Redis Key";
+    let label_type = c"Table Type";
+    let label_multi = c"Multi-Key Mode";
+    let label_pushdown = c"Pushdown";
+    let label_batch = c"Batch Size";
+
+    pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_key.as_ptr(), key_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_type.as_ptr(), type_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_multi.as_ptr(), multi_key_cstr.as_ptr(), es);
+
+    let pushdown_desc = if let Some(ref analysis) = state.pushdown_analysis {
+        if analysis.has_optimizations() {
+            analysis
+                .pushable_conditions
+                .iter()
+                .map(|c| format!("{} {} '{}'", c.column_name, c.operator, c.value))
+                .collect::<Vec<_>>()
+                .join(", ")
+        } else {
+            "none".to_string()
+        }
+    } else {
+        "none".to_string()
+    };
+    let pushdown_cstr = CString::new(pushdown_desc).unwrap_or_default();
+    pg_sys::ExplainPropertyText(label_pushdown.as_ptr(), pushdown_cstr.as_ptr(), es);
+
+    let label_batch_unit = c"rows";
+    pg_sys::ExplainPropertyInteger(
+        label_batch.as_ptr(),
+        label_batch_unit.as_ptr(),
+        state.batch_size as i64,
+        es,
+    );
+
+    if (*es).analyze {
+        let label_rows = c"Rows Fetched";
+        let label_rows_unit = c"rows";
+        pg_sys::ExplainPropertyInteger(
+            label_rows.as_ptr(),
+            label_rows_unit.as_ptr(),
+            state.row_count as i64,
+            es,
+        );
+    }
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn explain_foreign_modify(
+    _mtstate: *mut pg_sys::ModifyTableState,
+    rinfo: *mut pg_sys::ResultRelInfo,
+    _fdw_private: *mut pg_sys::List,
+    _subplan_index: ::core::ffi::c_int,
+    es: *mut pg_sys::ExplainState,
+) {
+    log!("---> explain_foreign_modify");
+    let fdw_state = (*rinfo).ri_FdwState as *mut RedisFdwState;
+    if fdw_state.is_null() {
+        return;
+    }
+    let state = &*fdw_state;
+
+    let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
+    let key_cstr = CString::new(state.table_key_prefix.as_str()).unwrap_or_default();
+    let type_name = state.table_type.redis_type_name();
+    let type_cstr = CString::new(type_name).unwrap_or_default();
+
+    let label_server = c"Redis Server";
+    let label_key = c"Redis Key";
+    let label_type = c"Table Type";
+
+    pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_key.as_ptr(), key_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_type.as_ptr(), type_cstr.as_ptr(), es);
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn get_foreign_modify_batch_size(
+    rinfo: *mut pg_sys::ResultRelInfo,
+) -> ::core::ffi::c_int {
+    log!("---> get_foreign_modify_batch_size");
+    let fdw_state = (*rinfo).ri_FdwState as *mut RedisFdwState;
+    if fdw_state.is_null() {
+        return 1;
+    }
+    let state = &*fdw_state;
+    state.batch_size as ::core::ffi::c_int
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn exec_foreign_batch_insert(
+    _estate: *mut pg_sys::EState,
+    rinfo: *mut pg_sys::ResultRelInfo,
+    slots: *mut *mut pg_sys::TupleTableSlot,
+    _plan_slots: *mut *mut pg_sys::TupleTableSlot,
+    num_slots: *mut ::core::ffi::c_int,
+) -> *mut *mut pg_sys::TupleTableSlot {
+    log!("---> exec_foreign_batch_insert");
+    let state = state_from_ptr((*rinfo).ri_FdwState);
+    let count = *num_slots as usize;
+
+    let mut rows: Vec<(Vec<String>, Option<i64>)> = Vec::with_capacity(count);
+    for i in 0..count {
+        let slot = *slots.add(i);
+        let row: Row = tuple_table_slot_to_row(slot);
+        let all_data: Vec<String> = row
+            .cells
+            .iter()
+            .map(|cell| cell_to_string(cell.as_ref()))
+            .collect();
+
+        let (data, row_ttl) = if let Some(ttl_idx) = state.ttl_column_index {
+            let ttl_val = all_data.get(ttl_idx).and_then(|s| {
+                if s == "NULL" {
+                    None
+                } else {
+                    s.parse::<i64>().ok()
+                }
+            });
+            let mut data = all_data;
+            if ttl_idx < data.len() {
+                data.remove(ttl_idx);
+            }
+            (data, ttl_val)
+        } else {
+            (all_data, None)
+        };
+        rows.push((data, row_ttl));
+    }
+
+    if let Err(e) = state.batch_insert_data(&rows) {
+        error!("{}", e);
+    }
+
+    for i in 0..count {
+        let slot = *slots.add(i);
+        (*slot).tts_tableOid = pg_sys::InvalidOid;
+    }
+
+    slots
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn exec_foreign_truncate(
+    rels: *mut pg_sys::List,
+    _behavior: pg_sys::DropBehavior::Type,
+    _restart_seqs: bool,
+) {
+    log!("---> exec_foreign_truncate");
+    use crate::core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory};
+    use crate::core::state_manager::is_multi_key_pattern;
+
+    if rels.is_null() {
+        return;
+    }
+
+    pgrx::memcx::current_context(|mcx| {
+        let rel_list = pgrx::list::List::<*mut std::ffi::c_void>::downcast_ptr_in_memcx(rels, mcx)
+            .expect("Failed to downcast rels list");
+
+        for rel_ptr in rel_list.iter() {
+            let relation = *rel_ptr as pg_sys::Relation;
+            if relation.is_null() {
+                continue;
+            }
+            let relid = (*relation).rd_id;
+            let options = get_foreign_table_options(relid);
+
+            let config = match RedisConnectionConfig::from_options(&options) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!("Failed to create Redis config for truncate: {}", e);
+                }
+            };
+
+            let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!("Failed to connect to Redis for truncate: {}", e);
+                }
+            };
+
+            let conn_like = conn.as_connection_like_mut();
+            let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
+
+            if is_multi_key_pattern(&key_prefix) {
+                let mut cursor: u64 = 0;
+                loop {
+                    pgrx::check_for_interrupts!();
+                    let (new_cursor, keys): (u64, Vec<String>) = match redis::cmd("SCAN")
+                        .arg(cursor)
+                        .arg("MATCH")
+                        .arg(&key_prefix)
+                        .arg("COUNT")
+                        .arg(1000u32)
+                        .query(conn_like)
+                    {
+                        Ok(r) => r,
+                        Err(e) => {
+                            error!("Redis SCAN error during truncate: {}", e);
+                        }
+                    };
+
+                    if !keys.is_empty() {
+                        let mut pipe = redis::pipe();
+                        for key in &keys {
+                            pipe.cmd("UNLINK").arg(key);
+                        }
+                        if let Err(e) = pipe.query::<Vec<redis::Value>>(conn_like) {
+                            error!("Redis UNLINK pipeline failed during truncate: {}", e);
+                        }
+                    }
+
+                    cursor = new_cursor;
+                    if cursor == 0 {
+                        break;
+                    }
+                }
+            } else if let Err(e) = redis::cmd("UNLINK")
+                .arg(&key_prefix)
+                .query::<i64>(conn_like)
+            {
+                error!("Redis UNLINK failed for key '{}': {}", key_prefix, e);
+            }
+        }
+    });
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn import_foreign_schema(
+    stmt: *mut pg_sys::ImportForeignSchemaStmt,
+    server_oid: pg_sys::Oid,
+) -> *mut pg_sys::List {
+    log!("---> import_foreign_schema");
+    use crate::core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory};
+    use std::collections::HashMap as StdHashMap;
+
+    let server = pg_sys::GetForeignServer(server_oid);
+    let mut options: StdHashMap<String, String> = StdHashMap::new();
+
+    pgrx::memcx::current_context(|mcx| {
+        if !(*server).options.is_null() {
+            let opts_list = pg_list_to_rust_list::<*mut std::ffi::c_void>((*server).options, mcx);
+            for option in opts_list.iter() {
+                let def_elem = (*option).cast::<pg_sys::DefElem>();
+                if !def_elem.is_null() {
+                    options.insert(
+                        string_from_cstr((*def_elem).defname),
+                        string_from_cstr(pg_sys::defGetString(def_elem)),
+                    );
+                }
+            }
+        }
+    });
+
+    let config = match RedisConnectionConfig::from_options(&options) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to create Redis config for import: {}", e);
+        }
+    };
+
+    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to connect to Redis for import: {}", e);
+        }
+    };
+
+    let conn_like = conn.as_connection_like_mut();
+
+    // SCAN to sample keys
+    let mut all_keys: Vec<String> = Vec::new();
+    let mut cursor: u64 = 0;
+    let max_keys: usize = 10_000;
+    loop {
+        pgrx::check_for_interrupts!();
+        let (new_cursor, keys): (u64, Vec<String>) = match redis::cmd("SCAN")
+            .arg(cursor)
+            .arg("COUNT")
+            .arg(1000u32)
+            .query(conn_like)
+        {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Redis SCAN error during import: {}", e);
+            }
+        };
+
+        all_keys.extend(keys);
+        cursor = new_cursor;
+        if cursor == 0 || all_keys.len() >= max_keys {
+            break;
+        }
+    }
+
+    if all_keys.len() > max_keys {
+        all_keys.truncate(max_keys);
+    }
+
+    if all_keys.is_empty() {
+        return ptr::null_mut();
+    }
+
+    // TYPE each key using pipeline
+    let mut pipe = redis::pipe();
+    for key in &all_keys {
+        pipe.cmd("TYPE").arg(key);
+    }
+    let types: Vec<String> = match pipe.query(conn_like) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Redis TYPE pipeline error during import: {}", e);
+        }
+    };
+
+    // Group keys by prefix and type
+    let mut groups: StdHashMap<String, String> = StdHashMap::new();
+    for (key, redis_type) in all_keys.iter().zip(types.iter()) {
+        if redis_type == "none" {
+            continue;
+        }
+        let prefix = derive_key_prefix(key);
+        groups.entry(prefix).or_insert_with(|| redis_type.clone());
+    }
+
+    // Build LIMIT TO / EXCEPT filter
+    let list_type = (*stmt).list_type;
+    let mut filter_names: Vec<String> = Vec::new();
+    if !(*stmt).table_list.is_null() {
+        pgrx::memcx::current_context(|mcx| {
+            let table_list = pgrx::list::List::<*mut std::ffi::c_void>::downcast_ptr_in_memcx(
+                (*stmt).table_list,
+                mcx,
+            )
+            .expect("Failed to downcast table_list");
+            for item in table_list.iter() {
+                let rv = *item as *mut pg_sys::RangeVar;
+                if !rv.is_null() && !(*rv).relname.is_null() {
+                    filter_names.push(string_from_cstr((*rv).relname));
+                }
+            }
+        });
+    }
+
+    // Generate DDL statements
+    let server_name = string_from_cstr((*stmt).server_name);
+    let mut result_list: *mut pg_sys::List = ptr::null_mut();
+
+    for (prefix, redis_type) in &groups {
+        let table_name = sanitize_table_name(prefix);
+
+        match list_type {
+            pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_LIMIT_TO
+                if !filter_names.contains(&table_name) =>
+            {
+                continue;
+            }
+            pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_EXCEPT
+                if filter_names.contains(&table_name) =>
+            {
+                continue;
+            }
+            _ => {}
+        }
+
+        let columns = columns_for_type(redis_type);
+        let key_pattern = format!("{}*", prefix);
+        let database_str = config.database.to_string();
+
+        let quoted_table = table_name.replace('"', "\"\"");
+        let quoted_server = server_name.replace('"', "\"\"");
+        let escaped_prefix = key_pattern.replace('\'', "''");
+
+        let ddl = format!(
+            "CREATE FOREIGN TABLE \"{}\" ({}) SERVER \"{}\" OPTIONS (database '{}', table_type '{}', table_key_prefix '{}')",
+            quoted_table, columns, quoted_server, database_str, redis_type, escaped_prefix
+        );
+
+        let ddl_cstr = match CString::new(ddl) {
+            Ok(c) => c,
+            Err(_) => {
+                error!("import_foreign_schema: table name contains null byte");
+            }
+        };
+        let pg_str = pg_sys::pstrdup(ddl_cstr.as_ptr());
+        result_list = pg_sys::lappend(result_list, pg_str as *mut std::ffi::c_void);
+    }
+
+    result_list
+}
+
+fn derive_key_prefix(key: &str) -> String {
+    if let Some(pos) = key.rfind(':') {
+        key[..=pos].to_string()
+    } else {
+        format!("{}_", key)
+    }
+}
+
+fn sanitize_table_name(prefix: &str) -> String {
+    let mut name: String = prefix
+        .trim_end_matches(':')
+        .trim_end_matches('_')
+        .replace([':', '-', '.'], "_")
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+
+    if name.starts_with(|c: char| c.is_ascii_digit()) {
+        name = format!("t_{}", name);
+    }
+
+    if name.is_empty() {
+        name = "redis_table".to_string();
+    }
+
+    if name.len() > 63 {
+        name.truncate(63);
+    }
+
+    name
+}
+
+fn columns_for_type(redis_type: &str) -> &'static str {
+    match redis_type {
+        "hash" => "key text, field text, value text",
+        "list" => "key text, element text",
+        "set" => "key text, member text",
+        "zset" => "key text, member text, score text",
+        "string" => "key text, value text",
+        "stream" => "stream_id text, field text, value text",
+        _ => "value text",
+    }
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn analyze_foreign_table(
+    relation: pg_sys::Relation,
+    func: *mut pg_sys::AcquireSampleRowsFunc,
+    totalpages: *mut pg_sys::BlockNumber,
+) -> bool {
+    log!("---> analyze_foreign_table");
+    use crate::core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory};
+    use crate::core::state_manager::is_multi_key_pattern;
+
+    let relid = (*relation).rd_id;
+    let options = get_foreign_table_options(relid);
+
+    let config = match RedisConnectionConfig::from_options(&options) {
+        Ok(c) => c,
+        Err(e) => {
+            log!("analyze_foreign_table: cannot create config: {}", e);
+            return false;
+        }
+    };
+
+    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
+        Ok(c) => c,
+        Err(e) => {
+            log!("analyze_foreign_table: cannot connect: {}", e);
+            return false;
+        }
+    };
+
+    let conn_like = conn.as_connection_like_mut();
+    let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
+    let table_type = options
+        .get("table_type")
+        .map(|s| s.as_str())
+        .unwrap_or("string");
+
+    let estimated_rows: u64 = if is_multi_key_pattern(&key_prefix) {
+        let mut cursor = 0u64;
+        let mut total_keys = 0u64;
+        let max_iterations = 100;
+        let mut iterations = 0;
+        loop {
+            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&key_prefix)
+                .arg("COUNT")
+                .arg(10000u32)
+                .query(conn_like)
+                .unwrap_or((0, Vec::new()));
+            total_keys += keys.len() as u64;
+            cursor = next_cursor;
+            iterations += 1;
+            if cursor == 0 || iterations >= max_iterations {
+                break;
+            }
+        }
+        total_keys
+    } else {
+        match table_type {
+            "hash" => redis::cmd("HLEN")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "list" => redis::cmd("LLEN")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "set" => redis::cmd("SCARD")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "zset" => redis::cmd("ZCARD")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "stream" => redis::cmd("XLEN")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "string" => {
+                let exists: u64 = redis::cmd("EXISTS")
+                    .arg(&key_prefix)
+                    .query(conn_like)
+                    .unwrap_or(0);
+                exists
+            }
+            _ => 0,
+        }
+    };
+
+    let avg_row_width: u64 = 100;
+    let pages =
+        ((estimated_rows * avg_row_width) / pg_sys::BLCKSZ as u64).max(1) as pg_sys::BlockNumber;
+    *totalpages = pages;
+    *func = Some(acquire_sample_rows);
+    true
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn acquire_sample_rows(
+    relation: pg_sys::Relation,
+    _elevel: ::core::ffi::c_int,
+    rows: *mut pg_sys::HeapTuple,
+    targrows: ::core::ffi::c_int,
+    totalrows: *mut f64,
+    totaldeadrows: *mut f64,
+) -> ::core::ffi::c_int {
+    log!("---> acquire_sample_rows (targrows={})", targrows);
+    use crate::core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory};
+    use crate::core::state_manager::is_multi_key_pattern;
+    use crate::query::limit::LimitOffsetInfo;
+
+    let relid = (*relation).rd_id;
+    let options = get_foreign_table_options(relid);
+    let tupdesc = (*relation).rd_att;
+    let natts = (*tupdesc).natts as usize;
+
+    let config = match RedisConnectionConfig::from_options(&options) {
+        Ok(c) => c,
+        Err(e) => {
+            log!("acquire_sample_rows: cannot create config: {}", e);
+            *totalrows = 0.0;
+            *totaldeadrows = 0.0;
+            return 0;
+        }
+    };
+
+    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
+        Ok(c) => c,
+        Err(e) => {
+            log!("acquire_sample_rows: cannot connect: {}", e);
+            *totalrows = 0.0;
+            *totaldeadrows = 0.0;
+            return 0;
+        }
+    };
+
+    let conn_like = conn.as_connection_like_mut();
+    let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
+    let table_type_str = options
+        .get("table_type")
+        .map(|s| s.as_str())
+        .unwrap_or("string");
+
+    let mut table_type = RedisTableType::from_str(table_type_str);
+    let is_multi_key = is_multi_key_pattern(&key_prefix);
+
+    let max_per_key = targrows as usize;
+    let sample_data: Vec<Vec<String>> = if is_multi_key {
+        let mut keys = Vec::new();
+        let mut cursor = 0u64;
+        loop {
+            let (next_cursor, batch): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&key_prefix)
+                .arg("COUNT")
+                .arg(targrows as u32)
+                .query(conn_like)
+                .unwrap_or((0, Vec::new()));
+            keys.extend(batch);
+            cursor = next_cursor;
+            if cursor == 0 || keys.len() >= max_per_key {
+                break;
+            }
+        }
+        keys.truncate(max_per_key);
+        let mut result = Vec::new();
+
+        if table_type_str == "string" {
+            let mut pipe = redis::pipe();
+            for key in &keys {
+                pipe.cmd("GET").arg(key);
+            }
+            let vals: Vec<String> = pipe.query(conn_like).unwrap_or_default();
+            for (key, val) in keys.iter().zip(vals.into_iter()) {
+                result.push(vec![key.clone(), val]);
+            }
+        } else {
+            for key in &keys {
+                if result.len() >= max_per_key {
+                    break;
+                }
+                let remaining = max_per_key - result.len();
+                match table_type_str {
+                    "hash" => {
+                        let (_, vals): (u64, Vec<String>) = redis::cmd("HSCAN")
+                            .arg(key)
+                            .arg(0u64)
+                            .arg("COUNT")
+                            .arg(remaining)
+                            .query(conn_like)
+                            .unwrap_or((0, Vec::new()));
+                        for chunk in vals.chunks(2).take(remaining) {
+                            if chunk.len() == 2 {
+                                result.push(vec![key.clone(), chunk[0].clone(), chunk[1].clone()]);
+                            }
+                        }
+                    }
+                    "list" => {
+                        let vals: Vec<String> = redis::cmd("LRANGE")
+                            .arg(key)
+                            .arg(0i64)
+                            .arg((remaining as i64) - 1)
+                            .query(conn_like)
+                            .unwrap_or_default();
+                        for v in vals {
+                            result.push(vec![key.clone(), v]);
+                        }
+                    }
+                    "set" => {
+                        let (_, vals): (u64, Vec<String>) = redis::cmd("SSCAN")
+                            .arg(key)
+                            .arg(0u64)
+                            .arg("COUNT")
+                            .arg(remaining)
+                            .query(conn_like)
+                            .unwrap_or((0, Vec::new()));
+                        for v in vals.into_iter().take(remaining) {
+                            result.push(vec![key.clone(), v]);
+                        }
+                    }
+                    "zset" => {
+                        let vals: Vec<String> = redis::cmd("ZRANGE")
+                            .arg(key)
+                            .arg(0i64)
+                            .arg((remaining as i64) - 1)
+                            .arg("WITHSCORES")
+                            .query(conn_like)
+                            .unwrap_or_default();
+                        for chunk in vals.chunks(2) {
+                            if chunk.len() == 2 {
+                                result.push(vec![key.clone(), chunk[1].clone(), chunk[0].clone()]);
+                            }
+                        }
+                    }
+                    _ => {
+                        result.push(vec![key.clone()]);
+                    }
+                }
+            }
+        }
+        result
+    } else {
+        let limit_info = LimitOffsetInfo {
+            limit: Some(targrows as usize),
+            offset: None,
+        };
+        let _ = table_type.load_data(conn_like, &key_prefix, None, &limit_info);
+
+        let mut result = Vec::new();
+        let len = table_type.data_len();
+        for i in 0..len {
+            if let Some(row_data) = table_type.get_row(i) {
+                result.push(row_data.into_iter().map(|c| c.into_owned()).collect());
+            }
+        }
+        result
+    };
+
+    let num_rows = sample_data.len().min(targrows as usize);
+    *totalrows = num_rows as f64;
+    *totaldeadrows = 0.0;
+
+    let mut actual = 0i32;
+    for (idx, row_data) in sample_data.iter().take(num_rows).enumerate() {
+        let mut values: Vec<pg_sys::Datum> = Vec::with_capacity(natts);
+        let mut nulls: Vec<bool> = Vec::with_capacity(natts);
+
+        for col_idx in 0..natts {
+            if col_idx < row_data.len() {
+                let attr = tuple_desc_attr(tupdesc, col_idx);
+                let typid = (*attr).atttypid;
+                let datum = get_datum(&row_data[col_idx], typid);
+                values.push(datum);
+                nulls.push(false);
+            } else {
+                values.push(pg_sys::Datum::from(0));
+                nulls.push(true);
+            }
+        }
+
+        let tuple = pg_sys::heap_form_tuple(tupdesc, values.as_mut_ptr(), nulls.as_mut_ptr());
+        *rows.add(idx) = tuple;
+        actual += 1;
+    }
+
+    actual
 }

--- a/src/core/pool_manager.rs
+++ b/src/core/pool_manager.rs
@@ -292,6 +292,8 @@ impl PoolManager {
         }
     }
 
+    const MAX_CACHED_POOLS: usize = 64;
+
     /// Get the global pool manager instance
     pub fn global() -> &'static RwLock<PoolManager> {
         POOL_MANAGER.get_or_init(|| RwLock::new(PoolManager::new()))
@@ -312,6 +314,15 @@ impl PoolManager {
         }
 
         let pool = Client::create_pool(host_port, database, auth_config, pool_config)?;
+
+        if self.single_pools.len() >= Self::MAX_CACHED_POOLS {
+            pgrx::warning!(
+                "Redis FDW: single pool cache full ({} pools), connection will not be cached",
+                Self::MAX_CACHED_POOLS
+            );
+            return Ok(pool);
+        }
+
         self.single_pools.insert(key, pool.clone());
         Ok(pool)
     }
@@ -331,6 +342,15 @@ impl PoolManager {
         }
 
         let pool = ClusterClient::create_pool(host_port, database, auth_config, pool_config)?;
+
+        if self.cluster_pools.len() >= Self::MAX_CACHED_POOLS {
+            pgrx::warning!(
+                "Redis FDW: cluster pool cache full ({} pools), connection will not be cached",
+                Self::MAX_CACHED_POOLS
+            );
+            return Ok(pool);
+        }
+
         self.cluster_pools.insert(key, pool.clone());
         Ok(pool)
     }
@@ -418,6 +438,13 @@ impl PooledConnection {
         match self {
             PooledConnection::Single(conn) => conn,
             PooledConnection::Cluster(conn) => conn,
+        }
+    }
+
+    pub fn as_cluster_connection_mut(&mut self) -> Option<&mut redis::cluster::ClusterConnection> {
+        match self {
+            PooledConnection::Cluster(conn) => Some(&mut *conn),
+            PooledConnection::Single(_) => None,
         }
     }
 }

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -65,7 +65,7 @@ impl RedisFdwState {
             cost_estimate: None,
             scan_cursor: 0,
             scan_complete: false,
-            batch_size: 1000,
+            batch_size: 5000,
             ttl_column_index: None,
             default_ttl: None,
             is_multi_key: false,
@@ -457,6 +457,8 @@ impl RedisFdwState {
         conn: &mut dyn redis::ConnectionLike,
         keys: &[String],
     ) -> usize {
+        const PER_KEY_WARN_THRESHOLD: usize = 200_000;
+
         let mut all_rows: Vec<String> =
             Vec::with_capacity(keys.len() * self.multi_key_columns_per_row());
 
@@ -487,6 +489,14 @@ impl RedisFdwState {
                     }
                 };
                 for (key, pairs) in keys.iter().zip(results) {
+                    pgrx::check_for_interrupts!();
+                    if pairs.len() > PER_KEY_WARN_THRESHOLD {
+                        pgrx::warning!(
+                            "Redis FDW: key '{}' contains {} elements, consider using LIMIT",
+                            key,
+                            pairs.len()
+                        );
+                    }
                     for (field, value) in pairs {
                         all_rows.push(key.clone());
                         all_rows.push(field);
@@ -506,6 +516,14 @@ impl RedisFdwState {
                     }
                 };
                 for (key, items) in keys.iter().zip(results) {
+                    pgrx::check_for_interrupts!();
+                    if items.len() > PER_KEY_WARN_THRESHOLD {
+                        pgrx::warning!(
+                            "Redis FDW: key '{}' contains {} elements, consider using LIMIT",
+                            key,
+                            items.len()
+                        );
+                    }
                     for item in items {
                         all_rows.push(key.clone());
                         all_rows.push(item);
@@ -524,6 +542,14 @@ impl RedisFdwState {
                     }
                 };
                 for (key, members) in keys.iter().zip(results) {
+                    pgrx::check_for_interrupts!();
+                    if members.len() > PER_KEY_WARN_THRESHOLD {
+                        pgrx::warning!(
+                            "Redis FDW: key '{}' contains {} elements, consider using LIMIT",
+                            key,
+                            members.len()
+                        );
+                    }
                     for member in members {
                         all_rows.push(key.clone());
                         all_rows.push(member);
@@ -546,6 +572,14 @@ impl RedisFdwState {
                     }
                 };
                 for (key, items) in keys.iter().zip(results) {
+                    pgrx::check_for_interrupts!();
+                    if items.len() > PER_KEY_WARN_THRESHOLD {
+                        pgrx::warning!(
+                            "Redis FDW: key '{}' contains {} elements, consider using LIMIT",
+                            key,
+                            items.len()
+                        );
+                    }
                     for (member, score) in items {
                         all_rows.push(key.clone());
                         all_rows.push(score.to_string());
@@ -558,6 +592,14 @@ impl RedisFdwState {
                 return 0;
             }
             RedisTableType::None => {}
+        }
+
+        const MULTI_KEY_WARN_THRESHOLD: usize = 1_000_000;
+        if all_rows.len() > MULTI_KEY_WARN_THRESHOLD {
+            pgrx::warning!(
+                "Redis FDW: multi-key batch accumulated {} elements, query may use excessive memory",
+                all_rows.len()
+            );
         }
 
         let cols_per_row = self.multi_key_columns_per_row();
@@ -664,6 +706,287 @@ impl RedisFdwState {
         if let Some(conn) = self.redis_connection.as_mut() {
             let conn_like = conn.as_connection_like_mut();
             self.table_type.update(conn_like, key, old_data, new_data)
+        } else {
+            Err(redis::RedisError::from((
+                redis::ErrorKind::Io,
+                "Redis connection not initialized",
+            )))
+        }
+    }
+
+    /// Batch insert multiple rows using Redis pipelining.
+    /// Handles cluster vs standalone internally. Applies TTL per row.
+    pub fn batch_insert_data(&mut self, rows: &[(Vec<String>, Option<i64>)]) -> Result<(), String> {
+        if let Some(ref mut conn) = self.redis_connection {
+            if let Some(cluster_conn) = conn.as_cluster_connection_mut() {
+                Self::batch_insert_cluster(
+                    cluster_conn,
+                    &self.table_type,
+                    &self.table_key_prefix,
+                    self.is_multi_key,
+                    self.default_ttl,
+                    rows,
+                )
+            } else {
+                let conn_like = conn.as_connection_like_mut();
+                Self::batch_insert_standalone(
+                    conn_like,
+                    &self.table_type,
+                    &self.table_key_prefix,
+                    self.is_multi_key,
+                    self.default_ttl,
+                    rows,
+                )
+            }
+        } else {
+            Err("Redis connection not available for batch insert".to_string())
+        }
+    }
+
+    fn batch_insert_standalone(
+        conn: &mut dyn redis::ConnectionLike,
+        table_type: &RedisTableType,
+        table_key_prefix: &str,
+        is_multi_key: bool,
+        default_ttl: Option<i64>,
+        rows: &[(Vec<String>, Option<i64>)],
+    ) -> Result<(), String> {
+        let mut pipe = redis::pipe();
+        let mut has_cmds = false;
+
+        for (data, row_ttl) in rows {
+            let (key, row_data) = if is_multi_key {
+                if data.is_empty() {
+                    continue;
+                }
+                (data[0].as_str(), &data[1..])
+            } else {
+                (table_key_prefix, data.as_slice())
+            };
+            if Self::add_insert_to_pipeline(&mut pipe, table_type, key, row_data) {
+                has_cmds = true;
+                has_cmds |= Self::add_ttl_to_pipeline(&mut pipe, key, *row_ttl, default_ttl);
+            }
+        }
+
+        if has_cmds {
+            pipe.query::<()>(conn)
+                .map_err(|e| format!("Redis batch insert pipeline failed: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn batch_insert_cluster(
+        cluster_conn: &mut redis::cluster::ClusterConnection,
+        table_type: &RedisTableType,
+        table_key_prefix: &str,
+        is_multi_key: bool,
+        default_ttl: Option<i64>,
+        rows: &[(Vec<String>, Option<i64>)],
+    ) -> Result<(), String> {
+        let mut pipe = redis::cluster::cluster_pipe();
+        let mut has_cmds = false;
+
+        for (data, row_ttl) in rows {
+            let (key, row_data) = if is_multi_key {
+                if data.is_empty() {
+                    continue;
+                }
+                (data[0].as_str(), &data[1..])
+            } else {
+                (table_key_prefix, data.as_slice())
+            };
+            if Self::add_insert_to_cluster_pipeline(&mut pipe, table_type, key, row_data) {
+                has_cmds = true;
+                has_cmds |=
+                    Self::add_ttl_to_cluster_pipeline(&mut pipe, key, *row_ttl, default_ttl);
+            }
+        }
+
+        if has_cmds {
+            pipe.query::<()>(cluster_conn)
+                .map_err(|e| format!("Redis cluster batch insert pipeline failed: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn add_insert_to_pipeline(
+        pipe: &mut redis::Pipeline,
+        table_type: &RedisTableType,
+        key: &str,
+        data: &[String],
+    ) -> bool {
+        match table_type {
+            RedisTableType::Hash(_) => {
+                if data.len() >= 2 {
+                    pipe.cmd("HSET").arg(key).arg(&data[0]).arg(&data[1]);
+                    return true;
+                }
+            }
+            RedisTableType::List(_) => {
+                if !data.is_empty() {
+                    pipe.cmd("RPUSH").arg(key).arg(&data[0]);
+                    return true;
+                }
+            }
+            RedisTableType::Set(_) => {
+                if !data.is_empty() {
+                    pipe.cmd("SADD").arg(key).arg(&data[0]);
+                    return true;
+                }
+            }
+            RedisTableType::ZSet(_) => {
+                if data.len() >= 2 {
+                    if data[1].parse::<f64>().is_ok() {
+                        pipe.cmd("ZADD").arg(key).arg(&data[1]).arg(&data[0]);
+                        return true;
+                    } else {
+                        pgrx::warning!(
+                            "ZSet batch insert: invalid score '{}' for member '{}', row skipped",
+                            data[1],
+                            data[0]
+                        );
+                    }
+                }
+            }
+            RedisTableType::String(_) => {
+                if !data.is_empty() {
+                    pipe.cmd("SET").arg(key).arg(&data[0]);
+                    return true;
+                }
+            }
+            RedisTableType::Stream(_) => {
+                if data.len() >= 3 {
+                    pipe.cmd("XADD")
+                        .arg(key)
+                        .arg("*")
+                        .arg(&data[1])
+                        .arg(&data[2]);
+                    return true;
+                }
+            }
+            RedisTableType::None => {}
+        }
+        false
+    }
+
+    fn add_insert_to_cluster_pipeline(
+        pipe: &mut redis::cluster::ClusterPipeline,
+        table_type: &RedisTableType,
+        key: &str,
+        data: &[String],
+    ) -> bool {
+        match table_type {
+            RedisTableType::Hash(_) => {
+                if data.len() >= 2 {
+                    pipe.cmd("HSET").arg(key).arg(&data[0]).arg(&data[1]);
+                    return true;
+                }
+            }
+            RedisTableType::List(_) => {
+                if !data.is_empty() {
+                    pipe.cmd("RPUSH").arg(key).arg(&data[0]);
+                    return true;
+                }
+            }
+            RedisTableType::Set(_) => {
+                if !data.is_empty() {
+                    pipe.cmd("SADD").arg(key).arg(&data[0]);
+                    return true;
+                }
+            }
+            RedisTableType::ZSet(_) => {
+                if data.len() >= 2 {
+                    if data[1].parse::<f64>().is_ok() {
+                        pipe.cmd("ZADD").arg(key).arg(&data[1]).arg(&data[0]);
+                        return true;
+                    } else {
+                        pgrx::warning!(
+                            "ZSet batch insert: invalid score '{}' for member '{}', row skipped",
+                            data[1],
+                            data[0]
+                        );
+                    }
+                }
+            }
+            RedisTableType::String(_) => {
+                if !data.is_empty() {
+                    pipe.cmd("SET").arg(key).arg(&data[0]);
+                    return true;
+                }
+            }
+            RedisTableType::Stream(_) => {
+                if data.len() >= 3 {
+                    pipe.cmd("XADD")
+                        .arg(key)
+                        .arg("*")
+                        .arg(&data[1])
+                        .arg(&data[2]);
+                    return true;
+                }
+            }
+            RedisTableType::None => {}
+        }
+        false
+    }
+
+    fn add_ttl_to_pipeline(
+        pipe: &mut redis::Pipeline,
+        key: &str,
+        row_ttl: Option<i64>,
+        default_ttl: Option<i64>,
+    ) -> bool {
+        let effective_ttl = match row_ttl {
+            Some(0) => return false,
+            Some(t) => t,
+            None => match default_ttl {
+                Some(t) => t,
+                None => return false,
+            },
+        };
+        if effective_ttl > 0 {
+            pipe.cmd("EXPIRE").arg(key).arg(effective_ttl);
+            true
+        } else if effective_ttl == -1 {
+            pipe.cmd("PERSIST").arg(key);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn add_ttl_to_cluster_pipeline(
+        pipe: &mut redis::cluster::ClusterPipeline,
+        key: &str,
+        row_ttl: Option<i64>,
+        default_ttl: Option<i64>,
+    ) -> bool {
+        let effective_ttl = match row_ttl {
+            Some(0) => return false,
+            Some(t) => t,
+            None => match default_ttl {
+                Some(t) => t,
+                None => return false,
+            },
+        };
+        if effective_ttl > 0 {
+            pipe.cmd("EXPIRE").arg(key).arg(effective_ttl);
+            true
+        } else if effective_ttl == -1 {
+            pipe.cmd("PERSIST").arg(key);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Delete a Redis key directly (for multi-key mode DELETE).
+    pub fn delete_key(&mut self, key: &str) -> Result<(), redis::RedisError> {
+        if let Some(conn) = self.redis_connection.as_mut() {
+            let conn_like = conn.as_connection_like_mut();
+            redis::cmd("DEL").arg(key).query::<()>(conn_like)
         } else {
             Err(redis::RedisError::from((
                 redis::ErrorKind::Io,

--- a/src/query/pushdown_types.rs
+++ b/src/query/pushdown_types.rs
@@ -24,6 +24,22 @@ pub enum ComparisonOperator {
     LessThanOrEqual,    // <=
 }
 
+impl std::fmt::Display for ComparisonOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ComparisonOperator::Equal => write!(f, "="),
+            ComparisonOperator::NotEqual => write!(f, "<>"),
+            ComparisonOperator::Like => write!(f, "LIKE"),
+            ComparisonOperator::In => write!(f, "IN"),
+            ComparisonOperator::NotIn => write!(f, "NOT IN"),
+            ComparisonOperator::GreaterThan => write!(f, ">"),
+            ComparisonOperator::GreaterThanOrEqual => write!(f, ">="),
+            ComparisonOperator::LessThan => write!(f, "<"),
+            ComparisonOperator::LessThanOrEqual => write!(f, "<="),
+        }
+    }
+}
+
 /// Result of WHERE clause analysis with LIMIT/OFFSET pushdown support
 #[derive(Debug, Clone)]
 pub struct PushdownAnalysis {

--- a/src/tests/fdw_callbacks_tests.rs
+++ b/src/tests/fdw_callbacks_tests.rs
@@ -1,0 +1,858 @@
+/// Integration tests for FDW callback extensions:
+/// - ExplainForeignScan / ExplainForeignModify
+/// - ExecForeignBatchInsert / GetForeignModifyBatchSize
+/// - ExecForeignTruncate
+/// - ImportForeignSchema
+///
+/// Prerequisites:
+///   - Redis server running on 127.0.0.1:8899
+///   - Database 15 available for testing
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    const REDIS_HOST_PORT: &str = "127.0.0.1:8899";
+    const TEST_DATABASE: &str = "15";
+    const FDW_NAME: &str = "fdw_callbacks_test_fdw";
+    const SERVER_NAME: &str = "fdw_callbacks_test_srv";
+
+    fn setup() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {FDW_NAME} CASCADE;"
+        ));
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {FDW_NAME} HANDLER redis_fdw_handler;"
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "CREATE SERVER {SERVER_NAME} FOREIGN DATA WRAPPER {FDW_NAME} \
+             OPTIONS (host_port '{REDIS_HOST_PORT}');"
+        ))
+        .unwrap();
+    }
+
+    fn teardown() {
+        let _ = Spi::run(&format!("DROP SERVER IF EXISTS {SERVER_NAME} CASCADE;"));
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {FDW_NAME} CASCADE;"
+        ));
+    }
+
+    fn create_table(name: &str, cols: &str, ttype: &str, key: &str) {
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {name} ({cols}) SERVER {SERVER_NAME} OPTIONS (\
+                database '{TEST_DATABASE}', table_type '{ttype}', table_key_prefix '{key}');"
+        ))
+        .unwrap();
+    }
+
+    fn create_table_with_batch(name: &str, cols: &str, ttype: &str, key: &str, batch_size: u32) {
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {name} ({cols}) SERVER {SERVER_NAME} OPTIONS (\
+                database '{TEST_DATABASE}', table_type '{ttype}', \
+                table_key_prefix '{key}', batch_size '{batch_size}');"
+        ))
+        .unwrap();
+    }
+
+    fn drop_table(name: &str) {
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {name};"));
+    }
+
+    fn count(table: &str) -> i64 {
+        Spi::get_one::<i64>(&format!("SELECT COUNT(*) FROM {table};"))
+            .unwrap()
+            .unwrap()
+    }
+
+    fn flush_key(key: &str) {
+        Spi::run("SELECT redis_fdw_handler(); -- ensure extension loaded").ok();
+        let client = redis::Client::open(format!("redis://{REDIS_HOST_PORT}")).unwrap();
+        let mut conn = client.get_connection().unwrap();
+        let _: () = redis::cmd("SELECT")
+            .arg(TEST_DATABASE)
+            .query(&mut conn)
+            .unwrap();
+        let _: () = redis::cmd("DEL").arg(key).query(&mut conn).unwrap();
+    }
+
+    fn flush_pattern(pattern: &str) {
+        let client = redis::Client::open(format!("redis://{REDIS_HOST_PORT}")).unwrap();
+        let mut conn = client.get_connection().unwrap();
+        let _: () = redis::cmd("SELECT")
+            .arg(TEST_DATABASE)
+            .query(&mut conn)
+            .unwrap();
+        let keys: Vec<String> = redis::cmd("KEYS").arg(pattern).query(&mut conn).unwrap();
+        for key in keys {
+            let _: () = redis::cmd("DEL").arg(&key).query(&mut conn).unwrap();
+        }
+    }
+
+    // ================================================
+    // EXPLAIN TESTS
+    // ================================================
+
+    #[pg_test]
+    fn test_explain_foreign_scan_hash() {
+        setup();
+        let table = "explain_scan_hash";
+        flush_key("explain:scan:hash");
+        create_table(table, "key text, value text", "hash", "explain:scan:hash");
+
+        Spi::run(&format!("INSERT INTO {table} VALUES ('f1', 'v1');")).unwrap();
+
+        let explain_output = Spi::get_one::<String>(&format!(
+            "EXPLAIN (FORMAT TEXT, VERBOSE) SELECT * FROM {table};"
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            explain_output.contains("Foreign Scan") || explain_output.contains("foreign"),
+            "EXPLAIN should show foreign scan info"
+        );
+
+        drop_table(table);
+        flush_key("explain:scan:hash");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_explain_analyze_foreign_scan() {
+        setup();
+        let table = "explain_analyze_scan";
+        flush_key("explain:analyze:data");
+        create_table(
+            table,
+            "key text, value text",
+            "hash",
+            "explain:analyze:data",
+        );
+
+        Spi::run(&format!("INSERT INTO {table} VALUES ('k1', 'v1');")).unwrap();
+        Spi::run(&format!("INSERT INTO {table} VALUES ('k2', 'v2');")).unwrap();
+
+        let explain_output = Spi::get_one::<String>(&format!(
+            "EXPLAIN (ANALYZE, FORMAT TEXT) SELECT * FROM {table};"
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            explain_output.contains("actual") || explain_output.contains("rows"),
+            "EXPLAIN ANALYZE should show actual execution info"
+        );
+
+        drop_table(table);
+        flush_key("explain:analyze:data");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_explain_foreign_modify() {
+        setup();
+        let table = "explain_modify_hash";
+        flush_key("explain:modify:hash");
+        create_table(table, "key text, value text", "hash", "explain:modify:hash");
+
+        let explain_output = Spi::get_one::<String>(&format!(
+            "EXPLAIN (FORMAT TEXT) INSERT INTO {table} VALUES ('k1', 'v1');"
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            explain_output.contains("Insert") || explain_output.contains("Foreign"),
+            "EXPLAIN INSERT should show modify plan"
+        );
+
+        drop_table(table);
+        flush_key("explain:modify:hash");
+        teardown();
+    }
+
+    // ================================================
+    // BATCH INSERT TESTS
+    // ================================================
+
+    #[pg_test]
+    fn test_batch_insert_hash() {
+        setup();
+        let table = "batch_ins_hash";
+        flush_key("batch:ins:hash");
+        create_table_with_batch(table, "key text, value text", "hash", "batch:ins:hash", 500);
+
+        // Insert multiple rows - PG will batch them via ExecForeignBatchInsert
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES \
+             ('f1', 'v1'), ('f2', 'v2'), ('f3', 'v3'), \
+             ('f4', 'v4'), ('f5', 'v5');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 5, "Batch insert should produce 5 rows in hash");
+
+        drop_table(table);
+        flush_key("batch:ins:hash");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_batch_insert_list() {
+        setup();
+        let table = "batch_ins_list";
+        flush_key("batch:ins:list");
+        create_table_with_batch(table, "element text", "list", "batch:ins:list", 500);
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('a'), ('b'), ('c'), ('d'), ('e'), ('f');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 6, "Batch insert should produce 6 rows in list");
+
+        drop_table(table);
+        flush_key("batch:ins:list");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_batch_insert_set() {
+        setup();
+        let table = "batch_ins_set";
+        flush_key("batch:ins:set");
+        create_table_with_batch(table, "member text", "set", "batch:ins:set", 500);
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('m1'), ('m2'), ('m3'), ('m4');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 4, "Batch insert should produce 4 rows in set");
+
+        drop_table(table);
+        flush_key("batch:ins:set");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_batch_insert_zset() {
+        setup();
+        let table = "batch_ins_zset";
+        flush_key("batch:ins:zset");
+        create_table_with_batch(
+            table,
+            "member text, score text",
+            "zset",
+            "batch:ins:zset",
+            500,
+        );
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('a', '1.0'), ('b', '2.0'), ('c', '3.0');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 3, "Batch insert should produce 3 rows in zset");
+
+        drop_table(table);
+        flush_key("batch:ins:zset");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_batch_insert_string_multi_key() {
+        setup();
+        let table = "batch_ins_str_mk";
+        flush_pattern("batchmk:str:*");
+        create_table_with_batch(
+            table,
+            "key text, value text",
+            "string",
+            "batchmk:str:*",
+            500,
+        );
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES \
+             ('batchmk:str:k1', 'v1'), ('batchmk:str:k2', 'v2'), ('batchmk:str:k3', 'v3');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(
+            cnt, 3,
+            "Batch insert multi-key string should produce 3 rows"
+        );
+
+        drop_table(table);
+        flush_pattern("batchmk:str:*");
+        teardown();
+    }
+
+    // ================================================
+    // TRUNCATE TESTS
+    // ================================================
+
+    #[pg_test]
+    fn test_truncate_single_key_hash() {
+        setup();
+        let table = "trunc_hash";
+        flush_key("trunc:hash:data");
+        create_table(table, "key text, value text", "hash", "trunc:hash:data");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('f1', 'v1'), ('f2', 'v2'), ('f3', 'v3');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 3, "Should have 3 rows before truncate");
+
+        Spi::run(&format!("TRUNCATE {table};")).unwrap();
+
+        let cnt_after = count(table);
+        assert_eq!(cnt_after, 0, "Should have 0 rows after truncate");
+
+        drop_table(table);
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_truncate_single_key_list() {
+        setup();
+        let table = "trunc_list";
+        flush_key("trunc:list:data");
+        create_table(table, "element text", "list", "trunc:list:data");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('a'), ('b'), ('c'), ('d');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 4, "Should have 4 rows before truncate");
+
+        Spi::run(&format!("TRUNCATE {table};")).unwrap();
+
+        let cnt_after = count(table);
+        assert_eq!(cnt_after, 0, "Should have 0 rows after truncate");
+
+        drop_table(table);
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_truncate_multi_key_pattern() {
+        setup();
+        let table = "trunc_mk";
+        flush_pattern("truncmk:*");
+        create_table(table, "key text, value text", "string", "truncmk:*");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('truncmk:k1', 'v1'), ('truncmk:k2', 'v2'), ('truncmk:k3', 'v3');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 3, "Should have 3 keys before truncate");
+
+        Spi::run(&format!("TRUNCATE {table};")).unwrap();
+
+        let cnt_after = count(table);
+        assert_eq!(cnt_after, 0, "Should have 0 keys after truncate");
+
+        drop_table(table);
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_truncate_set() {
+        setup();
+        let table = "trunc_set";
+        flush_key("trunc:set:data");
+        create_table(table, "member text", "set", "trunc:set:data");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('m1'), ('m2'), ('m3');"
+        ))
+        .unwrap();
+
+        Spi::run(&format!("TRUNCATE {table};")).unwrap();
+
+        let cnt_after = count(table);
+        assert_eq!(cnt_after, 0, "Set should be empty after truncate");
+
+        drop_table(table);
+        teardown();
+    }
+
+    // ================================================
+    // IMPORT FOREIGN SCHEMA TESTS
+    // ================================================
+
+    const IMPORT_SERVER_NAME: &str = "fdw_callbacks_import_srv";
+
+    fn setup_import_server() {
+        let _ = Spi::run(&format!(
+            "DROP SERVER IF EXISTS {IMPORT_SERVER_NAME} CASCADE;"
+        ));
+        Spi::run(&format!(
+            "CREATE SERVER {IMPORT_SERVER_NAME} FOREIGN DATA WRAPPER {FDW_NAME} \
+             OPTIONS (host_port '{REDIS_HOST_PORT}', database '{TEST_DATABASE}');"
+        ))
+        .unwrap();
+    }
+
+    #[pg_test]
+    fn test_import_foreign_schema_basic() {
+        setup();
+        setup_import_server();
+        flush_pattern("imptest:*");
+
+        // Seed Redis with known keys
+        let client = redis::Client::open(format!("redis://{REDIS_HOST_PORT}")).unwrap();
+        let mut conn = client.get_connection().unwrap();
+        let _: () = redis::cmd("SELECT")
+            .arg(TEST_DATABASE)
+            .query(&mut conn)
+            .unwrap();
+        let _: () = redis::cmd("HSET")
+            .arg("imptest:users:1")
+            .arg("name")
+            .arg("alice")
+            .query(&mut conn)
+            .unwrap();
+        let _: () = redis::cmd("HSET")
+            .arg("imptest:users:2")
+            .arg("name")
+            .arg("bob")
+            .query(&mut conn)
+            .unwrap();
+        let _: () = redis::cmd("SADD")
+            .arg("imptest:tags:post1")
+            .arg("rust")
+            .query(&mut conn)
+            .unwrap();
+
+        // Create a target schema for import
+        Spi::run("CREATE SCHEMA IF NOT EXISTS import_target;").unwrap();
+
+        // IMPORT FOREIGN SCHEMA should discover tables
+        let result = Spi::run(&format!(
+            "IMPORT FOREIGN SCHEMA \"public\" FROM SERVER {IMPORT_SERVER_NAME} INTO import_target;"
+        ));
+
+        // The import should succeed (may create tables based on discovered keys)
+        assert!(
+            result.is_ok(),
+            "IMPORT FOREIGN SCHEMA should succeed: {:?}",
+            result.err()
+        );
+
+        // Cleanup
+        let _ = Spi::run("DROP SCHEMA IF EXISTS import_target CASCADE;");
+        flush_pattern("imptest:*");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_import_foreign_schema_limit_to() {
+        setup();
+        setup_import_server();
+        flush_pattern("impft:*");
+
+        let client = redis::Client::open(format!("redis://{REDIS_HOST_PORT}")).unwrap();
+        let mut conn = client.get_connection().unwrap();
+        let _: () = redis::cmd("SELECT")
+            .arg(TEST_DATABASE)
+            .query(&mut conn)
+            .unwrap();
+        let _: () = redis::cmd("SET")
+            .arg("impft:config:timeout")
+            .arg("30")
+            .query(&mut conn)
+            .unwrap();
+        let _: () = redis::cmd("SET")
+            .arg("impft:cache:key1")
+            .arg("val1")
+            .query(&mut conn)
+            .unwrap();
+
+        Spi::run("CREATE SCHEMA IF NOT EXISTS import_limit_target;").unwrap();
+
+        // LIMIT TO a specific table name (derived from key prefix)
+        let result = Spi::run(&format!(
+            "IMPORT FOREIGN SCHEMA \"public\" LIMIT TO (impft_config) \
+             FROM SERVER {IMPORT_SERVER_NAME} INTO import_limit_target;"
+        ));
+
+        assert!(
+            result.is_ok(),
+            "IMPORT FOREIGN SCHEMA LIMIT TO should succeed: {:?}",
+            result.err()
+        );
+
+        let _ = Spi::run("DROP SCHEMA IF EXISTS import_limit_target CASCADE;");
+        flush_pattern("impft:*");
+        teardown();
+    }
+
+    // ================================================
+    // BATCH SIZE CONFIGURATION TESTS
+    // ================================================
+
+    #[pg_test]
+    fn test_batch_size_default() {
+        setup();
+        let table = "batchdef_hash";
+        flush_key("batchdef:hash");
+        // No batch_size option → default should be used (1000)
+        create_table(table, "key text, value text", "hash", "batchdef:hash");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('k1', 'v1'), ('k2', 'v2');"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 2, "Default batch should still work for small inserts");
+
+        drop_table(table);
+        flush_key("batchdef:hash");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_batch_insert_with_ttl() {
+        setup();
+        let table = "batch_ttl_hash";
+        flush_key("batch:ttl:hash");
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {table} (key text, value text, ttl bigint) \
+             SERVER {SERVER_NAME} OPTIONS (\
+                database '{TEST_DATABASE}', table_type 'hash', \
+                table_key_prefix 'batch:ttl:hash', batch_size '500');"
+        ))
+        .unwrap();
+
+        // Insert with explicit TTL
+        Spi::run(&format!(
+            "INSERT INTO {table} (key, value, ttl) VALUES ('f1', 'v1', 3600), ('f2', 'v2', 7200);"
+        ))
+        .unwrap();
+
+        let cnt = count(table);
+        assert_eq!(cnt, 2, "Batch insert with TTL should produce 2 rows");
+
+        // Check that TTL was applied
+        let ttl_val =
+            Spi::get_one::<i64>(&format!("SELECT ttl FROM {table} WHERE key = 'f1';")).unwrap();
+
+        assert!(
+            ttl_val.is_some() && ttl_val.unwrap() > 0,
+            "TTL should be set and positive"
+        );
+
+        drop_table(table);
+        flush_key("batch:ttl:hash");
+        teardown();
+    }
+
+    // ================================================
+    // EXPLAIN WITH PUSHDOWN TESTS
+    // ================================================
+
+    #[pg_test]
+    fn test_explain_with_pushdown_condition() {
+        setup();
+        let table = "explain_pd";
+        flush_key("explain:pd:data");
+        create_table(table, "key text, value text", "hash", "explain:pd:data");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('k1', 'v1'), ('k2', 'v2'), ('k3', 'v3');"
+        ))
+        .unwrap();
+
+        // EXPLAIN a query with WHERE clause pushdown
+        let explain_output = Spi::get_one::<String>(&format!(
+            "EXPLAIN (FORMAT TEXT) SELECT * FROM {table} WHERE key = 'k1';"
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            explain_output.contains("Foreign Scan") || explain_output.contains("Scan"),
+            "EXPLAIN with pushdown should show scan info"
+        );
+
+        drop_table(table);
+        flush_key("explain:pd:data");
+        teardown();
+    }
+
+    // ================================================
+    // ANALYZE TESTS
+    // ================================================
+
+    #[pg_test]
+    fn test_analyze_foreign_table_hash() {
+        setup();
+        let table = "analyze_hash";
+        flush_key("analyze:hash:data");
+        create_table(table, "key text, value text", "hash", "analyze:hash:data");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('f1', 'v1'), ('f2', 'v2'), ('f3', 'v3'), ('f4', 'v4'), ('f5', 'v5');"
+        ))
+        .unwrap();
+
+        let result = Spi::run(&format!("ANALYZE {table};"));
+        assert!(result.is_ok(), "ANALYZE should succeed on hash table");
+
+        let reltuples = Spi::get_one::<f32>(&format!(
+            "SELECT reltuples FROM pg_class WHERE relname = '{table}';"
+        ))
+        .unwrap()
+        .unwrap_or(0.0);
+
+        assert!(
+            reltuples > 0.0,
+            "pg_class.reltuples should be updated after ANALYZE, got {}",
+            reltuples
+        );
+
+        drop_table(table);
+        flush_key("analyze:hash:data");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_analyze_foreign_table_set() {
+        setup();
+        let table = "analyze_set";
+        flush_key("analyze:set:data");
+        create_table(table, "member text", "set", "analyze:set:data");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('m1'), ('m2'), ('m3');"
+        ))
+        .unwrap();
+
+        let result = Spi::run(&format!("ANALYZE {table};"));
+        assert!(result.is_ok(), "ANALYZE should succeed on set table");
+
+        let reltuples = Spi::get_one::<f32>(&format!(
+            "SELECT reltuples FROM pg_class WHERE relname = '{table}';"
+        ))
+        .unwrap()
+        .unwrap_or(0.0);
+
+        assert!(
+            reltuples > 0.0,
+            "pg_class.reltuples should be updated after ANALYZE for set, got {}",
+            reltuples
+        );
+
+        drop_table(table);
+        flush_key("analyze:set:data");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_analyze_foreign_table_multi_key() {
+        setup();
+        let table = "analyze_mk";
+        flush_pattern("analyzemk:*");
+        create_table(table, "key text, value text", "string", "analyzemk:*");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('analyzemk:k1', 'v1'), ('analyzemk:k2', 'v2'), ('analyzemk:k3', 'v3');"
+        ))
+        .unwrap();
+
+        let result = Spi::run(&format!("ANALYZE {table};"));
+        assert!(result.is_ok(), "ANALYZE should succeed on multi-key table");
+
+        let reltuples = Spi::get_one::<f32>(&format!(
+            "SELECT reltuples FROM pg_class WHERE relname = '{table}';"
+        ))
+        .unwrap()
+        .unwrap_or(0.0);
+
+        assert!(
+            reltuples > 0.0,
+            "pg_class.reltuples should be updated after ANALYZE for multi-key, got {}",
+            reltuples
+        );
+
+        drop_table(table);
+        flush_pattern("analyzemk:*");
+        teardown();
+    }
+
+    // ================================================
+    // BEGIN/END FOREIGN INSERT TESTS (COPY FROM, INSERT SELECT)
+    // ================================================
+
+    #[pg_test]
+    fn test_insert_select_cross_table() {
+        setup();
+        let src_table = "ins_sel_src";
+        let dst_table = "ins_sel_dst";
+        flush_key("inssel:src");
+        flush_key("inssel:dst");
+        create_table(src_table, "key text, value text", "hash", "inssel:src");
+        create_table(dst_table, "key text, value text", "hash", "inssel:dst");
+
+        Spi::run(&format!(
+            "INSERT INTO {src_table} VALUES ('f1', 'v1'), ('f2', 'v2'), ('f3', 'v3');"
+        ))
+        .unwrap();
+
+        // INSERT INTO ... SELECT ... triggers BeginForeignInsert
+        let result = Spi::run(&format!(
+            "INSERT INTO {dst_table} SELECT * FROM {src_table};"
+        ));
+        assert!(
+            result.is_ok(),
+            "INSERT INTO ... SELECT should succeed: {:?}",
+            result.err()
+        );
+
+        let cnt = count(dst_table);
+        assert_eq!(
+            cnt, 3,
+            "Destination table should have 3 rows from INSERT SELECT"
+        );
+
+        drop_table(src_table);
+        drop_table(dst_table);
+        flush_key("inssel:src");
+        flush_key("inssel:dst");
+        teardown();
+    }
+
+    #[pg_test]
+    fn test_insert_select_list() {
+        setup();
+        let src_table = "ins_sel_list_src";
+        let dst_table = "ins_sel_list_dst";
+        flush_key("inssel:list:src");
+        flush_key("inssel:list:dst");
+        create_table(src_table, "element text", "list", "inssel:list:src");
+        create_table(dst_table, "element text", "list", "inssel:list:dst");
+
+        Spi::run(&format!(
+            "INSERT INTO {src_table} VALUES ('a'), ('b'), ('c');"
+        ))
+        .unwrap();
+
+        let result = Spi::run(&format!(
+            "INSERT INTO {dst_table} SELECT * FROM {src_table};"
+        ));
+        assert!(
+            result.is_ok(),
+            "INSERT INTO ... SELECT for list should succeed: {:?}",
+            result.err()
+        );
+
+        let cnt = count(dst_table);
+        assert_eq!(cnt, 3, "Destination list should have 3 elements");
+
+        drop_table(src_table);
+        drop_table(dst_table);
+        flush_key("inssel:list:src");
+        flush_key("inssel:list:dst");
+        teardown();
+    }
+
+    // ================================================
+    // RECHECK / RESCAN TESTS
+    // ================================================
+
+    #[pg_test]
+    fn test_rescan_in_nested_loop() {
+        setup();
+        let table = "rescan_hash";
+        flush_key("rescan:hash");
+        create_table(table, "key text, value text", "hash", "rescan:hash");
+
+        Spi::run(&format!(
+            "INSERT INTO {table} VALUES ('k1', 'v1'), ('k2', 'v2'), ('k3', 'v3');"
+        ))
+        .unwrap();
+
+        // Create a local table to join with (forces nested loop / rescan)
+        Spi::run(
+            "CREATE TEMPORARY TABLE local_keys (k text); \
+             INSERT INTO local_keys VALUES ('k1'), ('k2');",
+        )
+        .unwrap();
+
+        let cnt = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM local_keys lk, {table} ft WHERE lk.k = ft.key;"
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(cnt, 2, "Join should return 2 matching rows");
+
+        drop_table(table);
+        let _ = Spi::run("DROP TABLE IF EXISTS local_keys;");
+        flush_key("rescan:hash");
+        teardown();
+    }
+
+    // ================================================
+    // BATCH INSERT REGRESSION TESTS
+    // ================================================
+
+    #[pg_test]
+    fn test_batch_insert_regression_after_refactor() {
+        setup();
+        let table = "batch_regr_hash";
+        flush_key("batch:regr:hash");
+        create_table_with_batch(
+            table,
+            "key text, value text",
+            "hash",
+            "batch:regr:hash",
+            100,
+        );
+
+        // Insert a larger batch to verify pipeline still works
+        let mut values = Vec::new();
+        for i in 0..50 {
+            values.push(format!("('field_{i}', 'value_{i}')"));
+        }
+        let values_str = values.join(", ");
+        Spi::run(&format!("INSERT INTO {table} VALUES {values_str};")).unwrap();
+
+        let cnt = count(table);
+        assert_eq!(
+            cnt, 50,
+            "Batch insert regression: should have 50 rows after refactor"
+        );
+
+        // Verify individual row correctness
+        let val = Spi::get_one::<String>(&format!(
+            "SELECT value FROM {table} WHERE key = 'field_25';"
+        ))
+        .unwrap()
+        .unwrap();
+        assert_eq!(val, "value_25", "Row content should be correct");
+
+        drop_table(table);
+        flush_key("batch:regr:hash");
+        teardown();
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -55,3 +55,6 @@ pub mod multi_key_tests;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub mod tls_tests;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod fdw_callbacks_tests;


### PR DESCRIPTION
- Add batch_insert_data() method to RedisFdwState that handles cluster vs standalone pipeline internally
- Add delete_key() method for multi-key mode DELETE
- Replace inline DEL command in exec_foreign_delete with delete_key()
- Remove build_insert_pipeline_cmd and build_insert_cluster_pipeline_cmd from handlers.rs (logic now in state_manager.rs)
- implement RecheckForeignScan and ShutdownForeignScan callbacks
- implement BeginForeignInsert and EndForeignInsert callbacks Enables COPY FROM and INSERT INTO ... SELECT into foreign tables. BeginForeignInsert initializes state with connection and TTL detection. EndForeignInsert destroys the memory context for cleanup.
- implement AnalyzeForeignTable with acquire_sample_rows Enables ANALYZE on foreign tables for better query planning. Uses type-specific Redis commands (HLEN, LLEN, SCARD, ZCARD, XLEN) for cardinality estimation, SCAN for multi-key patterns. acquire_sample_rows loads sample data and converts to HeapTuples.