### PR TITLE
feat/support-fdw-join

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 **Feature-complete for all CRUD operations plus EXPLAIN, batch INSERT, TRUNCATE, IMPORT FOREIGN SCHEMA, ANALYZE, and COPY FROM.** All Redis types (String, Hash, List, Set, ZSet) support SELECT, INSERT, UPDATE, DELETE, TRUNCATE. Stream supports SELECT, INSERT, DELETE, TRUNCATE only (append-only by design).
 
 ### Recent Work
+- JOIN support: FDW-to-FDW join pushdown for same-server tables with automatic join column detection from query clauses
+- Connection pool optimization: planning phase now connects to Redis for real cardinality statistics
 - FDW lifecycle refactoring: batch insert logic moved to `state_manager.batch_insert_data()`; handlers is now a thin dispatch layer
 - ANALYZE support: `analyze_foreign_table` + `acquire_sample_rows` for query planning statistics
 - COPY FROM / INSERT SELECT: `begin_foreign_insert` / `end_foreign_insert` callbacks
@@ -32,7 +34,7 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 
 ### Known Issues
 - Cluster integration tests (9 tests) fail without Redis Cluster infrastructure running
-- All non-cluster tests pass (331/331)
+- All non-cluster tests pass (including 16 JOIN tests and 4 pool performance tests)
 
 ## How to Work on This Project
 
@@ -53,6 +55,40 @@ cargo pgrx test pg14           # run all tests (needs Redis)
 cargo clippy --features pg14   # lint
 cargo fmt                      # format
 ```
+
+### Testing JOINs
+
+JOIN tests require both Redis and local PostgreSQL tables:
+
+```bash
+# Start Redis infrastructure
+make setup-redis
+
+# Run join-specific tests
+cargo pgrx test pg16 join_tests
+
+# Run pool performance tests
+cargo pgrx test pg16 pool_performance
+```
+
+JOIN tests create temporary local tables + Redis foreign tables and verify:
+- FDW-to-local INNER/LEFT JOINs return correct row counts
+- FDW-to-FDW same-server joins work with automatic column detection
+- Cross-type FDW-to-FDW joins (e.g., hash.field = zset.member)
+- JOIN + WHERE pushdown combinations
+- NULL padding for unmatched LEFT JOIN rows
+- Empty table edge cases
+- List type JOINs and String multi-key JOINs
+- Large dataset JOINs (100+ rows)
+- Rescan correctness (duplicate local rows trigger multiple scans)
+
+**Join pushdown eligibility requires ALL of:**
+1. Both tables on same Redis server (host_port match)
+2. Neither table in multi-key pattern mode (no glob in table_key_prefix)
+3. Neither table is a Stream type (variable-width rows not supported)
+4. Equality operator in join condition (`op_mergejoinable()` check)
+5. INNER JOIN or LEFT JOIN only (RIGHT/FULL not pushed down)
+6. Neither relation has base WHERE restrictions (`baserestrictinfo` must be empty)
 
 ### Adding a New Feature
 
@@ -104,8 +140,11 @@ FDW Callbacks (handlers.rs)
     ├── Import Schema: import_foreign_schema
     │       └── SCAN → TYPE pipeline → group by prefix → generate DDL
     │
-    └── Analyze: analyze_foreign_table → acquire_sample_rows
-            └── Enables ANALYZE for query planning (HLEN/SCARD/ZCARD/XLEN + sampling)
+    ├── Analyze: analyze_foreign_table → acquire_sample_rows
+    │       └── Enables ANALYZE for query planning (HLEN/SCARD/ZCARD/XLEN + sampling)
+    │
+    └── Join Pushdown: get_foreign_join_paths → plan_foreign_join → begin_foreign_join_scan
+            └── Same-server detection → hash-join execution (build/probe) → iterate results
                     │
                     ▼
               Redis (via R2D2 pool_manager.rs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,14 @@ cargo fmt
 - `src/core/` — FDW handler callbacks (`handlers.rs`), state management (`state_manager.rs`), connection pool (`pool_manager.rs`), connection factory (`connection_factory.rs`), DDL validator (`validator.rs`)
 - `src/tables/` — Trait interface (`interface.rs`), type enum + dispatch (`types.rs`, `macros.rs`), per-type implementations in `implementations/`
 - `src/query/` — WHERE pushdown (`pushdown.rs`), cost estimation (`cost_estimation.rs`), LIMIT handling (`limit.rs`), scan ops (`scan_ops.rs`)
+- `src/join/` — JOIN support: FDW-to-FDW pushdown (`foreign_join.rs`), types (`types.rs`)
 - `src/auth/` — Redis authentication
 - `src/utils/` — Cell/Row types, memory context helpers, general utilities
 
 ### FDW Lifecycle (PostgreSQL callbacks)
 1. **Planning**: `get_foreign_rel_size` → `get_foreign_paths` → `get_foreign_plan`
+   - Planning (`get_foreign_rel_size`) connects to Redis for real statistics (DBSIZE, HLEN, etc.)
+   - Planning releases connection immediately; `begin_foreign_scan` re-acquires from pool (fast path: read-lock only)
 2. **Scanning**: `begin_foreign_scan` → `iterate_foreign_scan` → `re_scan_foreign_scan` → `end_foreign_scan`
    - `recheck_foreign_scan` (returns true; no lossy filtering)
    - `shutdown_foreign_scan` (early connection release back to pool)
@@ -57,6 +60,7 @@ cargo fmt
 8. **Import Schema**: `import_foreign_schema` (SCAN → TYPE → group by prefix → generate DDL)
 9. **Analyze**: `analyze_foreign_table` → `acquire_sample_rows` (enables `ANALYZE` for query planning)
 10. **Updatability**: `is_foreign_rel_updatable` (bitmask: 28 for all types, 24 for stream)
+11. **Join Paths**: `get_foreign_join_paths` (FDW-to-FDW same-server pushdown with pipelined fetch)
 
 ### Trait Pattern
 All Redis types implement `RedisTableOperations` (in `src/tables/interface.rs`):
@@ -93,6 +97,18 @@ Stream is append-only; UPDATE returns an error at the trait level and `IsForeign
 - Data stored as flat `DataSet::Filtered(Vec<String>)` with N columns per row
 - First column is always the Redis key name
 - INSERT routes to specific key (first column); DELETE uses `DEL` on the full key
+
+### JOIN Architecture
+- **FDW-to-Local**: Standard nested-loop; PostgreSQL drives outer rows, FDW rescans inner on each iteration
+- **FDW-to-FDW**: `GetForeignJoinPaths` detects same-server tables, extracts join columns from restrictlist, creates pushdown join path
+- **Pushdown guards**: same server (host_port match), non-multi-key tables, non-Stream tables, merge-joinable (equality) operator, INNER/LEFT only, no base restrictions on either relation
+- **Base restriction guard**: If either relation has `baserestrictinfo` (WHERE clauses on individual tables), pushdown is skipped and PostgreSQL falls back to nested-loop which handles base quals correctly
+- **Join column detection**: Walks `extra.restrictlist` → `RestrictInfo` → `OpExpr` → validates `op_mergejoinable()` → `Var` nodes to find equality columns
+- **Join execution**: Fetch both datasets → build HashMap on smaller side → probe with larger side → LEFT JOIN NULL-pads unmatched outer rows
+- **NULL handling**: Unmatched LEFT JOIN columns produce `"NULL"` marker strings in result_data; `iterate_foreign_scan` translates these to SQL NULL (`tts_isnull = true`) before returning tuples
+- **OOM protection**: Pre-checks cardinality with O(1) commands (HLEN/SCARD/ZCARD/LLEN) before fetch; hard limit at 500K rows per dataset
+- **Memory lifecycle**: `result_data` freed early in `shutdown_foreign_scan` (before `end_foreign_scan` destroys the memory context)
+- **Connection lifecycle**: acquired at `get_foreign_rel_size` for cost estimation, released immediately; re-acquired from pool at `begin_foreign_scan`, transferred to `RedisJoinState` for join execution, released at `shutdown_foreign_scan`
 
 ### FDW Validator
 - `redis_fdw_validator_wrapper` — raw C function (not `#[pg_extern]`) with `pg_finfo`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A high-performance Redis Foreign Data Wrapper (FDW) for PostgreSQL written in Ru
 - **IMPORT FOREIGN SCHEMA**: Auto-discovers Redis keys, groups by prefix, and generates DDL
 - **ANALYZE**: Statistics gathering for query planner via type-specific cardinality commands
 - **COPY FROM**: Bulk loading via `COPY` and `INSERT INTO ... SELECT` into foreign tables
+- **JOIN support**: FDW-to-FDW join pushdown for same-server tables with automatic join column detection
 - **OOM protection**: Soft limits with warnings for large datasets and connection pool saturation
 - **Compatible with PostgreSQL 14-18**
 
@@ -427,6 +428,73 @@ redis_fdw_rs=#  SELECT * FROM user_profiles where key like '555%';
  55513 | value_55513
  55548 | value_55548
 --More--
+```
+
+## JOIN Support
+
+### FDW-to-Local Table JOINs
+
+Redis foreign tables can be joined with regular PostgreSQL tables using standard nested-loop plans:
+
+```sql
+SELECT u.name, r.value
+FROM users u
+JOIN redis_hash_table r ON u.key = r.field;
+```
+
+The FDW provides accurate cardinality estimates to PostgreSQL's planner, enabling optimal join strategy selection. Each outer row triggers a full rescan of the Redis table.
+
+### FDW-to-FDW JOINs (Same Server Pushdown)
+
+When both sides of a JOIN are Redis foreign tables on the same server, the FDW pushes the join down — fetching both datasets in a single connection and performing an in-memory hash join:
+
+```sql
+-- Both tables on same Redis server → single-connection fetch + hash join
+SELECT h.field, h.value, s.member
+FROM redis_hash h
+JOIN redis_set s ON h.field = s.member;
+```
+
+The FDW automatically detects which columns are used in the join condition from the query. Supported join types: INNER JOIN, LEFT JOIN.
+
+**Limitations:**
+- FDW-to-FDW pushdown requires both tables on the same Redis server (same `host_port`)
+- Only single-column equality joins are pushed down (merge-joinable operators)
+- Neither table can have base WHERE restrictions (these force nested-loop fallback)
+- Multi-key pattern tables (glob in `table_key_prefix`) cannot be push-down joined
+- Stream tables are not eligible for join pushdown (variable-width rows)
+- RIGHT JOIN and FULL OUTER JOIN are not pushed down (handled via nested-loop)
+- Both datasets are loaded into memory for the hash join (warning emitted if >500K rows)
+- Redis command errors during join fetch are raised as SQL errors (no silent data loss)
+- LEFT JOIN unmatched rows produce proper SQL NULLs (not string literals)
+
+### Performance Tips for JOINs
+
+- Use `EXPLAIN` to verify the planner chose an efficient strategy (look for "Foreign Scan" on the join relation)
+- For large Redis datasets, add WHERE conditions to reduce data volume before the join
+- FDW-to-FDW same-server joins avoid redundant connection overhead (single pooled connection for both datasets)
+- The smaller dataset is always used as the hash-join build side for optimal memory usage
+
+## Connection Pool Configuration
+
+Configure pool behavior via server OPTIONS:
+
+| Option | Default | Range | Description |
+|--------|---------|-------|-------------|
+| `pool_max_size` | 16 | 1-512 | Maximum connections in pool |
+| `pool_min_idle` | 1 | 0-max_size | Minimum idle connections |
+| `pool_connection_timeout_ms` | 30000 | 100-60000 | Timeout to acquire connection |
+| `pool_max_lifetime_secs` | 1800 | 60-7200 | Max connection lifetime |
+| `pool_idle_timeout_secs` | 600 | 30-3600 | Idle connection timeout |
+
+Example:
+```sql
+CREATE SERVER redis_server FOREIGN DATA WRAPPER redis_fdw
+OPTIONS (
+    host_port '127.0.0.1:6379',
+    pool_max_size '32',
+    pool_min_idle '4'
+);
 ```
 
 ## Development

--- a/src/core/connection_factory.rs
+++ b/src/core/connection_factory.rs
@@ -12,7 +12,6 @@ use crate::{
 /// reuse across queries, significantly improving performance under concurrent workloads.
 use pgrx::prelude::*;
 use std::collections::HashMap;
-use std::time::Duration;
 
 /// Errors that can occur during connection creation
 #[derive(Debug, thiserror::Error)]
@@ -44,7 +43,6 @@ pub struct RedisConnectionConfig {
     pub host_port: String,
     pub database: i64,
     pub retry_attempts: Option<u32>,
-    pub retry_delay: Option<Duration>,
     pub auth_config: RedisAuthConfig,
     pub pool_config: PoolConfig,
 }
@@ -71,7 +69,6 @@ impl RedisConnectionConfig {
             host_port,
             database,
             retry_attempts: Some(3),
-            retry_delay: Some(Duration::from_millis(100)),
             auth_config: RedisAuthConfig::from_user_mapping_options(opts),
             pool_config: PoolConfig::from_options(opts),
         };
@@ -120,7 +117,6 @@ impl RedisConnectionFactory {
         config: &RedisConnectionConfig,
     ) -> ConnectionFactoryResult<PooledConnection> {
         let retry_attempts = config.retry_attempts.unwrap_or(3);
-        let retry_delay = config.retry_delay.unwrap_or(Duration::from_millis(100));
 
         for attempt in 1..=retry_attempts {
             match Self::create_pooled_connection(config) {
@@ -132,13 +128,9 @@ impl RedisConnectionFactory {
                     return Ok(connection);
                 }
                 Err(e) if attempt < retry_attempts => {
-                    log!(
-                        "Connection attempt {} failed, retrying in {:?}: {}",
-                        attempt,
-                        retry_delay,
-                        e
-                    );
-                    std::thread::sleep(retry_delay);
+                    log!("Connection attempt {} failed, retrying: {}", attempt, e);
+                    pgrx::check_for_interrupts!();
+                    std::thread::sleep(std::time::Duration::from_millis(100 * attempt as u64));
                 }
                 Err(e) => {
                     return Err(ConnectionFactoryError::ConnectionFailed(format!(

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -1,5 +1,9 @@
 use crate::{
     core::state_manager::RedisFdwState,
+    join::{
+        foreign_join::execute_foreign_join,
+        types::{RedisJoinState, RedisJoinType},
+    },
     query::{limit::extract_limit_offset_info, pushdown::WhereClausePushdown},
     tables::types::RedisTableType,
     utils::{helpers::*, memory::create_wrappers_memctx, row::Row},
@@ -90,6 +94,9 @@ pub extern "C" fn redis_fdw_handler() -> FdwRoutine {
         // analyze
         fdw_routine.AnalyzeForeignTable = Some(analyze_foreign_table);
 
+        // join pushdown (FDW-to-FDW on same Redis server)
+        fdw_routine.GetForeignJoinPaths = Some(get_foreign_join_paths);
+
         fdw_routine
     }
 }
@@ -117,6 +124,14 @@ extern "C-unwind" fn get_foreign_rel_size(
             state.table_type = RedisTableType::from_str(table_type_str);
         }
 
+        // Connect to Redis for real statistics gathering
+        if let Err(e) = state.init_redis_connection_from_options() {
+            log!(
+                "Could not connect to Redis for cost estimation, using defaults: {}",
+                e
+            );
+        }
+
         // Calculate cost estimate using actual Redis statistics
         let cost_estimate = state.estimate_costs();
         log!(
@@ -126,6 +141,9 @@ extern "C-unwind" fn get_foreign_rel_size(
             cost_estimate.total_cost,
             cost_estimate.width
         );
+
+        // Release planning-phase connection back to pool immediately, begin_foreign_scan will re-acquire from pool (fast path: read-lock only).
+        state.redis_connection = None;
 
         // Store the estimate for use in get_foreign_paths
         let estimated_rows = cost_estimate.rows;
@@ -193,14 +211,19 @@ unsafe extern "C-unwind" fn get_foreign_plan(
     root: *mut pgrx::pg_sys::PlannerInfo,
     baserel: *mut pgrx::pg_sys::RelOptInfo,
     foreigntableid: pgrx::pg_sys::Oid,
-    _best_path: *mut pgrx::pg_sys::ForeignPath,
+    best_path: *mut pgrx::pg_sys::ForeignPath,
     tlist: *mut pgrx::pg_sys::List,
     scan_clauses: *mut pgrx::pg_sys::List,
     outer_plan: *mut pgrx::pg_sys::Plan,
 ) -> *mut pgrx::pg_sys::ForeignScan {
     log!("---> get_foreign_plan");
 
-    // Get the FDW state from baserel to analyze table type
+    // Join relation: scanrelid=0, build join plan
+    if (*baserel).reloptkind == pg_sys::RelOptKind::RELOPT_JOINREL {
+        return plan_foreign_join(root, baserel, best_path, tlist, scan_clauses, outer_plan);
+    }
+
+    // Base relation: normal scan plan
     let state = state_from_ptr((*baserel).fdw_private);
 
     PgMemoryContexts::For(state.tmp_ctx).switch_to(|_| {
@@ -254,6 +277,123 @@ unsafe extern "C-unwind" fn get_foreign_plan(
     )
 }
 
+unsafe fn plan_foreign_join(
+    _root: *mut pgrx::pg_sys::PlannerInfo,
+    joinrel: *mut pgrx::pg_sys::RelOptInfo,
+    best_path: *mut pgrx::pg_sys::ForeignPath,
+    tlist: *mut pgrx::pg_sys::List,
+    scan_clauses: *mut pgrx::pg_sys::List,
+    outer_plan: *mut pgrx::pg_sys::Plan,
+) -> *mut pgrx::pg_sys::ForeignScan {
+    log!("---> plan_foreign_join");
+
+    // Extract outer/inner state from the ForeignPath's fdw_private
+    let path_private = (*best_path).fdw_private;
+    let outer_state_ptr = deserialize_nth_ptr_from_list(path_private, 0) as *mut RedisFdwState;
+    let inner_state_ptr = deserialize_nth_ptr_from_list(path_private, 1) as *mut RedisFdwState;
+
+    if outer_state_ptr.is_null() || inner_state_ptr.is_null() {
+        pgrx::error!("Join plan: missing outer/inner state in fdw_private");
+    }
+
+    let outer_state = &*outer_state_ptr;
+    let inner_state = &*inner_state_ptr;
+
+    // Read the join type from the third list element
+    let jointype_val = deserialize_nth_ptr_from_list(path_private, 2) as i64;
+    let join_type = if jointype_val == pgrx::pg_sys::JoinType::JOIN_LEFT as i64 {
+        RedisJoinType::Left
+    } else {
+        RedisJoinType::Inner
+    };
+
+    // Read join columns from 4th and 5th list elements
+    let join_col_outer = deserialize_nth_ptr_from_list(path_private, 3) as usize;
+    let join_col_inner = deserialize_nth_ptr_from_list(path_private, 4) as usize;
+
+    // Read relation IDs from 6th and 7th list elements
+    let outer_relid = deserialize_nth_ptr_from_list(path_private, 5) as pg_sys::Index;
+    let inner_relid = deserialize_nth_ptr_from_list(path_private, 6) as pg_sys::Index;
+
+    // Build the RedisJoinState with table info from both sides
+    let join_state = RedisJoinState::new(
+        outer_state.table_type.clone(),
+        inner_state.table_type.clone(),
+        outer_state.table_key_prefix.clone(),
+        inner_state.table_key_prefix.clone(),
+        join_type,
+        join_col_outer,
+        join_col_inner,
+    );
+
+    // Create a new RedisFdwState for the join scan
+    let ctx_name = "Wrappers_join_scan";
+    let ctx = create_wrappers_memctx(ctx_name);
+    let mut state = RedisFdwState::new(ctx);
+
+    // Copy connection info from outer (same server guaranteed by get_foreign_join_paths)
+    state.host_port = outer_state.host_port.clone();
+    state.database = outer_state.database;
+    state.opts = outer_state.opts.clone();
+    state.is_join_scan = true;
+    state.join_state = Some(join_state);
+
+    let state_ptr = PgMemoryContexts::For(ctx).leak_and_drop_on_delete(state);
+    (*joinrel).fdw_private = state_ptr as *mut std::os::raw::c_void;
+
+    let outer_ncols = crate::join::foreign_join::expected_columns_for_type(&outer_state.table_type);
+    let inner_ncols = crate::join::foreign_join::expected_columns_for_type(&inner_state.table_type);
+
+    // Build fdw_scan_tlist: declare our scan produces [outer_col1..N, inner_col1..M]
+    // This matches the combined row layout from execute_foreign_join.
+    // Since we skip pushdown when base restrictions exist (checked in
+    // get_foreign_join_paths), all quals here only reference join columns
+    // that are already in the tlist.
+    let mut fdw_scan_tlist: *mut pg_sys::List = ptr::null_mut();
+    let mut resno: i16 = 1;
+
+    for attno in 1..=(outer_ncols as i16) {
+        let var = pg_sys::makeVar(
+            outer_relid as _,
+            attno,
+            pg_sys::TEXTOID,
+            -1,
+            pg_sys::DEFAULT_COLLATION_OID,
+            0,
+        );
+        let tle = pg_sys::makeTargetEntry(var as *mut pg_sys::Expr, resno, ptr::null_mut(), false);
+        fdw_scan_tlist = pg_sys::lappend(fdw_scan_tlist, tle as *mut std::ffi::c_void);
+        resno += 1;
+    }
+    for attno in 1..=(inner_ncols as i16) {
+        let var = pg_sys::makeVar(
+            inner_relid as _,
+            attno,
+            pg_sys::TEXTOID,
+            -1,
+            pg_sys::DEFAULT_COLLATION_OID,
+            0,
+        );
+        let tle = pg_sys::makeTargetEntry(var as *mut pg_sys::Expr, resno, ptr::null_mut(), false);
+        fdw_scan_tlist = pg_sys::lappend(fdw_scan_tlist, tle as *mut std::ffi::c_void);
+        resno += 1;
+    }
+
+    let fdw_private = serialize_ptr_to_list(state_ptr as *mut std::os::raw::c_void);
+    let local_quals = pg_sys::extract_actual_clauses(scan_clauses, false);
+
+    pgrx::pg_sys::make_foreignscan(
+        tlist,
+        local_quals, // apply any joinrel-level quals locally after scan
+        0,           // scanrelid=0 for join
+        ptr::null_mut(),
+        fdw_private as _,
+        fdw_scan_tlist,
+        ptr::null_mut(),
+        outer_plan,
+    )
+}
+
 #[pg_guard]
 extern "C-unwind" fn begin_foreign_scan(
     node: *mut pgrx::pg_sys::ForeignScanState,
@@ -263,6 +403,15 @@ extern "C-unwind" fn begin_foreign_scan(
     unsafe {
         let scan_state = (*node).ss;
         let plan: *mut pg_sys::ForeignScan = scan_state.ps.plan as *mut pg_sys::ForeignScan;
+        let scanrelid = (*plan).scan.scanrelid;
+
+        // Join scan: scanrelid == 0 means this is a pushed-down join
+        if scanrelid == 0 {
+            begin_foreign_join_scan(node, plan);
+            return;
+        }
+
+        // Normal base relation scan
         let relation = (*node).ss.ss_currentRelation;
         let relid = (*relation).rd_id;
         let state_ptr = deserialize_ptr_from_list((*plan).fdw_private as _);
@@ -272,9 +421,11 @@ extern "C-unwind" fn begin_foreign_scan(
             log!("Foreign table options: {:?}", options);
             state.update_from_options(options);
 
-            // Initialize Redis connection and handle potential errors
-            if let Err(e) = state.init_redis_connection_from_options() {
-                pgrx::error!("Failed to connect to Redis: {}", e);
+            // Acquire connection from pool (fast path: read-lock on existing pool)
+            if state.redis_connection.is_none() {
+                if let Err(e) = state.init_redis_connection_from_options() {
+                    pgrx::error!("Failed to connect to Redis: {}", e);
+                }
             }
 
             state.set_table_type();
@@ -296,6 +447,29 @@ extern "C-unwind" fn begin_foreign_scan(
     }
 }
 
+unsafe fn begin_foreign_join_scan(
+    node: *mut pgrx::pg_sys::ForeignScanState,
+    plan: *mut pg_sys::ForeignScan,
+) {
+    log!("---> begin_foreign_join_scan");
+    let state_ptr = deserialize_ptr_from_list((*plan).fdw_private as _);
+    let state = state_from_ptr(state_ptr);
+
+    // Connect to Redis for the join execution
+    if state.redis_connection.is_none() {
+        if let Err(e) = state.init_redis_connection_from_options() {
+            pgrx::error!("Failed to connect to Redis for join scan: {}", e);
+        }
+    }
+
+    // Transfer connection to the join_state so execute_foreign_join can use it
+    if let Some(ref mut join_state) = state.join_state {
+        join_state.connection = state.redis_connection.take();
+    }
+
+    (*node).fdw_state = state_ptr;
+}
+
 #[pg_guard]
 unsafe extern "C-unwind" fn iterate_foreign_scan(
     node: *mut pgrx::pg_sys::ForeignScanState,
@@ -307,6 +481,34 @@ unsafe extern "C-unwind" fn iterate_foreign_scan(
     let tupdesc = (*slot).tts_tupleDescriptor;
 
     exec_clear_tuple(slot);
+
+    // Join pushdown mode: execute join on first call, then iterate results
+    if state.is_join_scan {
+        if let Some(ref mut join_state) = state.join_state {
+            if !state.join_executed {
+                execute_foreign_join(join_state);
+                state.join_executed = true;
+            }
+            if join_state.current_row < join_state.result_data.len() {
+                let row = &join_state.result_data[join_state.current_row];
+                let natts = (*tupdesc).natts as usize;
+                for (col_idx, value) in row.iter().enumerate().take(natts) {
+                    match value {
+                        None => {
+                            (*slot).tts_isnull.add(col_idx).write(true);
+                        }
+                        Some(v) => {
+                            write_datum_to_slot(slot, tupdesc, col_idx, v);
+                        }
+                    }
+                }
+                join_state.current_row += 1;
+                pgrx::pg_sys::ExecStoreVirtualTuple(slot);
+                return slot;
+            }
+        }
+        return slot;
+    }
 
     // Streaming iteration: if current batch is exhausted, fetch more
     if state.is_read_end() {
@@ -420,13 +622,19 @@ extern "C-unwind" fn re_scan_foreign_scan(node: *mut pgrx::pg_sys::ForeignScanSt
         }
         let state = &mut *fdw_state;
 
-        // Reset iteration and streaming state for rescan
-        state.row_count = 0;
-        state.scan_cursor = 0;
-        state.scan_complete = false;
-        state.cached_ttl = None;
-        state.multi_key_ttl_cache.clear();
-        state.table_type.clear_data();
+        if state.is_join_scan {
+            // Reset iterator to re-read materialized results without re-fetching from Redis
+            if let Some(ref mut join_state) = state.join_state {
+                join_state.current_row = 0;
+            }
+        } else {
+            state.row_count = 0;
+            state.scan_cursor = 0;
+            state.scan_complete = false;
+            state.cached_ttl = None;
+            state.multi_key_ttl_cache.clear();
+            state.table_type.clear_data();
+        }
     }
 }
 
@@ -449,6 +657,10 @@ extern "C-unwind" fn shutdown_foreign_scan(node: *mut pgrx::pg_sys::ForeignScanS
         }
         let state = &mut *fdw_state;
         state.redis_connection = None;
+        if let Some(ref mut join_state) = state.join_state {
+            join_state.connection = None;
+            join_state.result_data = Vec::new();
+        }
     }
 }
 
@@ -841,6 +1053,28 @@ unsafe extern "C-unwind" fn explain_foreign_scan(
         return;
     }
     let state = &*fdw_state;
+
+    if state.is_join_scan {
+        let label_join = c"Redis Join";
+        let join_desc = if let Some(ref js) = state.join_state {
+            format!(
+                "{}({}) x {}({})",
+                js.outer_table_type.redis_type_name(),
+                js.outer_key_prefix,
+                js.inner_table_type.redis_type_name(),
+                js.inner_key_prefix
+            )
+        } else {
+            "FDW-to-FDW pushdown".to_string()
+        };
+        let join_cstr = CString::new(join_desc).unwrap_or_default();
+        pg_sys::ExplainPropertyText(label_join.as_ptr(), join_cstr.as_ptr(), es);
+
+        let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
+        let label_server = c"Redis Server";
+        pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
+        return;
+    }
 
     let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
     let key_cstr = CString::new(state.table_key_prefix.as_str()).unwrap_or_default();
@@ -1576,4 +1810,217 @@ unsafe extern "C-unwind" fn acquire_sample_rows(
     }
 
     actual
+}
+
+/// Extract join column indices from the join restrictlist.
+/// Returns (outer_col_0based, inner_col_0based) if an equality condition is found
+/// between a Var on the outer rel and a Var on the inner rel.
+unsafe fn extract_join_columns(
+    extra: *mut pgrx::pg_sys::JoinPathExtraData,
+    outerrel: *mut pgrx::pg_sys::RelOptInfo,
+    innerrel: *mut pgrx::pg_sys::RelOptInfo,
+) -> Option<(usize, usize)> {
+    if extra.is_null() {
+        return None;
+    }
+
+    let restrictlist = (*extra).restrictlist;
+    if restrictlist.is_null() {
+        return None;
+    }
+
+    let outer_relids = (*outerrel).relids;
+    let inner_relids = (*innerrel).relids;
+
+    let restrict_items: Vec<*mut pg_sys::Node> = pgrx::memcx::current_context(|mcx| {
+        let list = pg_list_to_rust_list::<*mut std::ffi::c_void>(restrictlist, mcx);
+        list.iter().map(|item| *item as *mut pg_sys::Node).collect()
+    });
+
+    for node in &restrict_items {
+        let node = *node;
+        if node.is_null() {
+            continue;
+        }
+
+        // Unwrap RestrictInfo wrapper
+        let clause = if (*node).type_ == pg_sys::NodeTag::T_RestrictInfo {
+            let ri = node as *mut pg_sys::RestrictInfo;
+            (*ri).clause as *mut pg_sys::Node
+        } else {
+            node
+        };
+
+        if clause.is_null() || (*clause).type_ != pg_sys::NodeTag::T_OpExpr {
+            continue;
+        }
+
+        let op_expr = &*(clause as *mut pg_sys::OpExpr);
+
+        // Must be a merge-joinable (equality) operator with exactly 2 args
+        if !pg_sys::op_mergejoinable(op_expr.opno, pg_sys::InvalidOid) {
+            continue;
+        }
+
+        if pg_sys::list_length(op_expr.args) != 2 {
+            continue;
+        }
+
+        let left_arg = pg_sys::list_nth(op_expr.args, 0) as *mut pg_sys::Node;
+        let right_arg = pg_sys::list_nth(op_expr.args, 1) as *mut pg_sys::Node;
+
+        if left_arg.is_null() || right_arg.is_null() {
+            continue;
+        }
+
+        // Both args must be Var nodes
+        if (*left_arg).type_ != pg_sys::NodeTag::T_Var
+            || (*right_arg).type_ != pg_sys::NodeTag::T_Var
+        {
+            continue;
+        }
+
+        let left_var = &*(left_arg as *mut pg_sys::Var);
+        let right_var = &*(right_arg as *mut pg_sys::Var);
+
+        // Check which var belongs to outer/inner
+        let left_in_outer = pg_sys::bms_is_member(left_var.varno as i32, outer_relids);
+        let left_in_inner = pg_sys::bms_is_member(left_var.varno as i32, inner_relids);
+        let right_in_outer = pg_sys::bms_is_member(right_var.varno as i32, outer_relids);
+        let right_in_inner = pg_sys::bms_is_member(right_var.varno as i32, inner_relids);
+
+        if left_in_outer && right_in_inner && left_var.varattno > 0 && right_var.varattno > 0 {
+            let outer_col = (left_var.varattno - 1) as usize;
+            let inner_col = (right_var.varattno - 1) as usize;
+            return Some((outer_col, inner_col));
+        } else if right_in_outer && left_in_inner && right_var.varattno > 0 && left_var.varattno > 0
+        {
+            let outer_col = (right_var.varattno - 1) as usize;
+            let inner_col = (left_var.varattno - 1) as usize;
+            return Some((outer_col, inner_col));
+        }
+    }
+
+    None
+}
+
+#[pg_guard]
+unsafe extern "C-unwind" fn get_foreign_join_paths(
+    root: *mut pgrx::pg_sys::PlannerInfo,
+    joinrel: *mut pgrx::pg_sys::RelOptInfo,
+    outerrel: *mut pgrx::pg_sys::RelOptInfo,
+    innerrel: *mut pgrx::pg_sys::RelOptInfo,
+    jointype: pgrx::pg_sys::JoinType::Type,
+    _extra: *mut pgrx::pg_sys::JoinPathExtraData,
+) {
+    log!("---> get_foreign_join_paths");
+
+    if jointype != pgrx::pg_sys::JoinType::JOIN_INNER
+        && jointype != pgrx::pg_sys::JoinType::JOIN_LEFT
+    {
+        log!("Unsupported join type for pushdown");
+        return;
+    }
+
+    let outer_state_ptr = (*outerrel).fdw_private as *mut RedisFdwState;
+    let inner_state_ptr = (*innerrel).fdw_private as *mut RedisFdwState;
+
+    if outer_state_ptr.is_null() || inner_state_ptr.is_null() {
+        log!("One or both relations lack FDW state, cannot push down join");
+        return;
+    }
+
+    let outer_state = &*outer_state_ptr;
+    let inner_state = &*inner_state_ptr;
+
+    if outer_state.host_port != inner_state.host_port {
+        log!(
+            "Relations on different servers ({} vs {}), cannot push down",
+            outer_state.host_port,
+            inner_state.host_port
+        );
+        return;
+    }
+
+    // Multi-key pattern tables use SCAN-based iteration; pushdown not supported
+    if outer_state.is_multi_key || inner_state.is_multi_key {
+        log!("Multi-key pattern table detected, join pushdown not supported");
+        return;
+    }
+
+    // Stream tables have variable-width rows; pushdown not supported
+    if matches!(outer_state.table_type, RedisTableType::Stream(_))
+        || matches!(inner_state.table_type, RedisTableType::Stream(_))
+    {
+        log!("Stream table detected, join pushdown not supported");
+        return;
+    }
+
+    // Skip pushdown when either base relation has WHERE restrictions.
+    // Our pushdown fetches all data from both sides; PG's base restrictions
+    // assume the base scan already filtered rows. Without a way to re-evaluate
+    // base quals in the join scan, fall back to nested-loop which handles them.
+    if !(*outerrel).baserestrictinfo.is_null()
+        && pg_sys::list_length((*outerrel).baserestrictinfo) > 0
+    {
+        log!("Outer relation has base restrictions, skipping join pushdown");
+        return;
+    }
+    if !(*innerrel).baserestrictinfo.is_null()
+        && pg_sys::list_length((*innerrel).baserestrictinfo) > 0
+    {
+        log!("Inner relation has base restrictions, skipping join pushdown");
+        return;
+    }
+
+    // Extract join columns from the restrictlist in JoinPathExtraData
+    let (join_col_outer, join_col_inner) = match extract_join_columns(_extra, outerrel, innerrel) {
+        Some(cols) => cols,
+        None => {
+            log!("No equality join clause found between FDW rels, cannot push down");
+            return;
+        }
+    };
+
+    log!(
+        "Detected join columns: outer={}, inner={}",
+        join_col_outer,
+        join_col_inner
+    );
+
+    let outer_rows = (*outerrel).rows;
+    let inner_rows = (*innerrel).rows;
+    let startup_cost = 15.0;
+    let total_cost = startup_cost + outer_rows + inner_rows + (outer_rows.min(inner_rows) * 0.02);
+
+    let joinrel_rows = outer_rows.min(inner_rows);
+
+    // Store outer+inner state pointers, jointype, join columns, and relids
+    let fdw_private = serialize_join_info_to_list(&[
+        outer_state_ptr as i64,
+        inner_state_ptr as i64,
+        jointype as i64,
+        join_col_outer as i64,
+        join_col_inner as i64,
+        (*outerrel).relid as i64,
+        (*innerrel).relid as i64,
+    ]);
+
+    let path = pgrx::pg_sys::create_foreign_join_path(
+        root,
+        joinrel,
+        ptr::null_mut(),
+        joinrel_rows,
+        #[cfg(feature = "pg18")]
+        0,
+        startup_cost,
+        total_cost,
+        ptr::null_mut(),
+        (*joinrel).lateral_relids,
+        ptr::null_mut(),
+        #[cfg(any(feature = "pg17", feature = "pg18"))]
+        ptr::null_mut(),
+        fdw_private,
+    );
+    pgrx::pg_sys::add_path(joinrel, path as *mut pgrx::pg_sys::Path);
 }

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -47,6 +47,12 @@ pub struct RedisFdwState {
     pub cached_ttl: Option<i64>,
     /// Cached TTL values for multi-key mode (batch-fetched via pipeline)
     pub multi_key_ttl_cache: HashMap<String, i64>,
+    /// Whether this is a join pushdown scan (FDW-to-FDW on same server)
+    pub is_join_scan: bool,
+    /// Join execution state (populated during begin_foreign_scan for join scans)
+    pub join_state: Option<crate::join::types::RedisJoinState>,
+    /// Whether the join has been executed (lazy: execute on first iterate call)
+    pub join_executed: bool,
 }
 
 impl RedisFdwState {
@@ -71,6 +77,9 @@ impl RedisFdwState {
             is_multi_key: false,
             cached_ttl: None,
             multi_key_ttl_cache: HashMap::new(),
+            is_join_scan: false,
+            join_state: None,
+            join_executed: false,
         }
     }
 

--- a/src/join/foreign_join.rs
+++ b/src/join/foreign_join.rs
@@ -1,0 +1,222 @@
+use crate::join::types::{RedisJoinState, RedisJoinType};
+use crate::tables::types::RedisTableType;
+use std::collections::HashMap;
+
+const MAX_JOIN_DATASET_ROWS: usize = 500_000;
+
+pub fn execute_foreign_join(state: &mut RedisJoinState) -> usize {
+    let conn = match state.connection.as_mut() {
+        Some(c) => c.as_connection_like_mut(),
+        None => {
+            pgrx::error!("Redis FDW: no connection available for join execution");
+        }
+    };
+
+    let outer_data = fetch_dataset(conn, &state.outer_table_type, &state.outer_key_prefix);
+    let inner_data = fetch_dataset(conn, &state.inner_table_type, &state.inner_key_prefix);
+
+    if outer_data.len() > MAX_JOIN_DATASET_ROWS || inner_data.len() > MAX_JOIN_DATASET_ROWS {
+        pgrx::warning!(
+            "Redis FDW: join materializing large datasets (outer={}, inner={})",
+            outer_data.len(),
+            inner_data.len()
+        );
+    }
+
+    let (build_data, probe_data, build_col, probe_col, build_is_outer) =
+        if outer_data.len() <= inner_data.len() {
+            (
+                &outer_data,
+                &inner_data,
+                state.join_column_outer,
+                state.join_column_inner,
+                true,
+            )
+        } else {
+            (
+                &inner_data,
+                &outer_data,
+                state.join_column_inner,
+                state.join_column_outer,
+                false,
+            )
+        };
+
+    let mut hash_table: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (idx, row) in build_data.iter().enumerate() {
+        if let Some(key) = row.get(build_col) {
+            hash_table.entry(key.as_str()).or_default().push(idx);
+        }
+    }
+
+    let inner_cols = expected_columns_for_type(&state.inner_table_type);
+
+    let mut result: Vec<Vec<Option<String>>> = Vec::new();
+    let mut matched_build: Vec<bool> = vec![false; build_data.len()];
+
+    let null_pad_row: Vec<Option<String>> =
+        if state.join_type == RedisJoinType::Left && !build_is_outer {
+            vec![None; inner_cols]
+        } else {
+            Vec::new()
+        };
+
+    for probe_row in probe_data {
+        if let Some(probe_key) = probe_row.get(probe_col) {
+            if let Some(build_indices) = hash_table.get(probe_key.as_str()) {
+                for &build_idx in build_indices {
+                    matched_build[build_idx] = true;
+                    let combined = if build_is_outer {
+                        to_option_row(&build_data[build_idx], probe_row)
+                    } else {
+                        to_option_row(probe_row, &build_data[build_idx])
+                    };
+                    result.push(combined);
+                }
+            } else if state.join_type == RedisJoinType::Left && !build_is_outer {
+                let mut combined = to_some_vec(probe_row);
+                combined.extend_from_slice(&null_pad_row);
+                result.push(combined);
+            }
+        } else if state.join_type == RedisJoinType::Left && !build_is_outer {
+            let mut combined = to_some_vec(probe_row);
+            combined.extend_from_slice(&null_pad_row);
+            result.push(combined);
+        }
+    }
+
+    if state.join_type == RedisJoinType::Left && build_is_outer {
+        let null_inner: Vec<Option<String>> = vec![None; inner_cols];
+        for (idx, matched) in matched_build.iter().enumerate() {
+            if !matched {
+                let mut combined = to_some_vec(&build_data[idx]);
+                combined.extend_from_slice(&null_inner);
+                result.push(combined);
+            }
+        }
+    }
+
+    let count = result.len();
+    state.result_columns = result.first().map_or(0, |r| r.len());
+    state.result_data = result;
+    state.current_row = 0;
+    count
+}
+
+fn fetch_dataset(
+    conn: &mut dyn redis::ConnectionLike,
+    table_type: &RedisTableType,
+    key_prefix: &str,
+) -> Vec<Vec<String>> {
+    // Pre-check cardinality to avoid OOM from unbounded HGETALL/SMEMBERS
+    let cardinality: u64 = match table_type {
+        RedisTableType::Hash(_) => redis::cmd("HLEN").arg(key_prefix).query(conn),
+        RedisTableType::Set(_) => redis::cmd("SCARD").arg(key_prefix).query(conn),
+        RedisTableType::ZSet(_) => redis::cmd("ZCARD").arg(key_prefix).query(conn),
+        RedisTableType::List(_) => redis::cmd("LLEN").arg(key_prefix).query(conn),
+        RedisTableType::Stream(_) => redis::cmd("XLEN").arg(key_prefix).query(conn),
+        _ => Ok(0),
+    }
+    .unwrap_or_else(|e| {
+        pgrx::error!(
+            "Redis FDW: failed to get cardinality for key '{}': {}",
+            key_prefix,
+            e
+        )
+    });
+    if cardinality > MAX_JOIN_DATASET_ROWS as u64 {
+        pgrx::error!(
+            "Redis FDW: join dataset '{}' has {} elements, exceeding limit of {}. Use a WHERE clause to reduce data volume.",
+            key_prefix,
+            cardinality,
+            MAX_JOIN_DATASET_ROWS
+        );
+    }
+
+    match table_type {
+        RedisTableType::Hash(_) => {
+            let pairs: Vec<(String, String)> = redis::cmd("HGETALL")
+                .arg(key_prefix)
+                .query(conn)
+                .unwrap_or_else(|e| {
+                    pgrx::error!("Redis FDW: HGETALL '{}' failed: {}", key_prefix, e);
+                });
+            pairs.into_iter().map(|(f, v)| vec![f, v]).collect()
+        }
+        RedisTableType::Set(_) => {
+            let members: Vec<String> = redis::cmd("SMEMBERS")
+                .arg(key_prefix)
+                .query(conn)
+                .unwrap_or_else(|e| {
+                    pgrx::error!("Redis FDW: SMEMBERS '{}' failed: {}", key_prefix, e);
+                });
+            members.into_iter().map(|m| vec![m]).collect()
+        }
+        RedisTableType::ZSet(_) => {
+            let items: Vec<(String, f64)> = redis::cmd("ZRANGE")
+                .arg(key_prefix)
+                .arg(0i64)
+                .arg(-1i64)
+                .arg("WITHSCORES")
+                .query(conn)
+                .unwrap_or_else(|e| {
+                    pgrx::error!("Redis FDW: ZRANGE '{}' failed: {}", key_prefix, e);
+                });
+            items
+                .into_iter()
+                .map(|(member, score)| vec![member, score.to_string()])
+                .collect()
+        }
+        RedisTableType::List(_) => {
+            let items: Vec<String> = redis::cmd("LRANGE")
+                .arg(key_prefix)
+                .arg(0i64)
+                .arg(-1i64)
+                .query(conn)
+                .unwrap_or_else(|e| {
+                    pgrx::error!("Redis FDW: LRANGE '{}' failed: {}", key_prefix, e);
+                });
+            items.into_iter().map(|v| vec![v]).collect()
+        }
+        RedisTableType::String(_) => {
+            let val: Option<String> = redis::cmd("GET")
+                .arg(key_prefix)
+                .query(conn)
+                .unwrap_or_else(|e| {
+                    pgrx::error!("Redis FDW: GET '{}' failed: {}", key_prefix, e);
+                });
+            match val {
+                Some(v) => vec![vec![key_prefix.to_string(), v]],
+                None => vec![],
+            }
+        }
+        _ => vec![],
+    }
+}
+
+pub fn expected_columns_for_type(table_type: &RedisTableType) -> usize {
+    match table_type {
+        RedisTableType::Hash(_) => 2,
+        RedisTableType::Set(_) => 1,
+        RedisTableType::ZSet(_) => 2,
+        RedisTableType::List(_) => 1,
+        RedisTableType::String(_) => 2,
+        RedisTableType::Stream(_) => 3,
+        RedisTableType::None => 0,
+    }
+}
+
+fn to_option_row(outer: &[String], inner: &[String]) -> Vec<Option<String>> {
+    let mut combined = Vec::with_capacity(outer.len() + inner.len());
+    for s in outer {
+        combined.push(Some(s.clone()));
+    }
+    for s in inner {
+        combined.push(Some(s.clone()));
+    }
+    combined
+}
+
+fn to_some_vec(data: &[String]) -> Vec<Option<String>> {
+    data.iter().map(|s| Some(s.clone())).collect()
+}

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -1,0 +1,2 @@
+pub mod foreign_join;
+pub mod types;

--- a/src/join/types.rs
+++ b/src/join/types.rs
@@ -1,0 +1,48 @@
+use crate::core::pool_manager::PooledConnection;
+use crate::tables::types::RedisTableType;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RedisJoinType {
+    Inner,
+    Left,
+}
+
+pub struct RedisJoinState {
+    pub connection: Option<PooledConnection>,
+    pub outer_table_type: RedisTableType,
+    pub inner_table_type: RedisTableType,
+    pub outer_key_prefix: String,
+    pub inner_key_prefix: String,
+    pub join_type: RedisJoinType,
+    pub join_column_outer: usize,
+    pub join_column_inner: usize,
+    pub result_data: Vec<Vec<Option<String>>>,
+    pub current_row: usize,
+    pub result_columns: usize,
+}
+
+impl RedisJoinState {
+    pub fn new(
+        outer_table_type: RedisTableType,
+        inner_table_type: RedisTableType,
+        outer_key_prefix: String,
+        inner_key_prefix: String,
+        join_type: RedisJoinType,
+        join_column_outer: usize,
+        join_column_inner: usize,
+    ) -> Self {
+        Self {
+            connection: None,
+            outer_table_type,
+            inner_table_type,
+            outer_key_prefix,
+            inner_key_prefix,
+            join_type,
+            join_column_outer,
+            join_column_inner,
+            result_data: Vec::new(),
+            current_row: 0,
+            result_columns: 0,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ mod core;
 // Query processing and optimization
 mod query;
 
+// JOIN support (parameterized paths and FDW-to-FDW pushdown)
+mod join;
+
 // Table type implementations
 mod tables;
 

--- a/src/tests/join_tests.rs
+++ b/src/tests/join_tests.rs
@@ -1,0 +1,949 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    const REDIS_HOST_PORT: &str = "127.0.0.1:8899";
+    const TEST_DATABASE: &str = "15";
+    const FDW_NAME: &str = "redis_join_wrapper";
+    const SERVER_NAME: &str = "redis_join_server";
+
+    fn setup_join_fdw() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {} HANDLER redis_fdw_handler;",
+            FDW_NAME
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '{}');",
+            SERVER_NAME, FDW_NAME, REDIS_HOST_PORT
+        ))
+        .unwrap();
+    }
+
+    fn cleanup_join_fdw() {
+        let _ = Spi::run(&format!("DROP SERVER IF EXISTS {} CASCADE;", SERVER_NAME));
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+    }
+
+    fn create_join_table(table_name: &str, columns: &str, table_type: &str, key_prefix: &str) {
+        let sql = format!(
+            "CREATE FOREIGN TABLE {table_name} ({columns}) SERVER {SERVER_NAME} OPTIONS (
+                database '{TEST_DATABASE}',
+                table_type '{table_type}',
+                table_key_prefix '{key_prefix}'
+            );"
+        );
+        Spi::run(&sql).unwrap();
+    }
+
+    #[pg_test]
+    fn test_join_hash_with_local_table() {
+        setup_join_fdw();
+
+        Spi::run("CREATE TEMPORARY TABLE join_local (id text, name text);").unwrap();
+        Spi::run("INSERT INTO join_local VALUES ('a', 'Alice'), ('b', 'Bob'), ('c', 'Charlie');")
+            .unwrap();
+
+        let table_name = "join_hash_local";
+        let key_prefix = "join_test:hash_local";
+        create_join_table(table_name, "field text, value text", "hash", key_prefix);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('a', 'val_a'), ('b', 'val_b'), ('d', 'val_d');",
+            table_name
+        ))
+        .unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_local l JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 2, "INNER JOIN should find 2 matches (a, b)");
+
+        let left_count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_local l LEFT JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(left_count, 3, "LEFT JOIN should return all 3 local rows");
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'a';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'b';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'd';", table_name)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_set_with_local_table() {
+        setup_join_fdw();
+
+        Spi::run("CREATE TEMPORARY TABLE join_local_set (id text);").unwrap();
+        Spi::run("INSERT INTO join_local_set VALUES ('member1'), ('member2'), ('missing');")
+            .unwrap();
+
+        let table_name = "join_set_local";
+        let key_prefix = "join_test:set_local";
+        create_join_table(table_name, "member text", "set", key_prefix);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('member1'), ('member2'), ('member3');",
+            table_name
+        ))
+        .unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_local_set l JOIN {} r ON l.id = r.member;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 2, "Should match member1 and member2");
+
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'member1';",
+            table_name
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'member2';",
+            table_name
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'member3';",
+            table_name
+        ))
+        .unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_local_set;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_two_redis_tables() {
+        setup_join_fdw();
+
+        let hash_table = "join_fdw_hash";
+        let set_table = "join_fdw_set";
+        let hash_key = "join_test:fdw_hash";
+        let set_key = "join_test:fdw_set";
+
+        create_join_table(hash_table, "field text, value text", "hash", hash_key);
+        create_join_table(set_table, "member text", "set", set_key);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('x', 'val_x'), ('y', 'val_y'), ('z', 'val_z');",
+            hash_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('x'), ('y'), ('w');",
+            set_table
+        ))
+        .unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM {} h JOIN {} s ON h.field = s.member;",
+            hash_table, set_table
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 2, "FDW-to-FDW join should find 2 matches (x, y)");
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'x';", hash_table)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'y';", hash_table)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'z';", hash_table)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'x';", set_table)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'y';", set_table)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'w';", set_table)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", hash_table));
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", set_table));
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_with_where_pushdown() {
+        setup_join_fdw();
+
+        Spi::run("CREATE TEMPORARY TABLE join_where_local (id text);").unwrap();
+        Spi::run("INSERT INTO join_where_local VALUES ('field1'), ('field2'), ('field3');")
+            .unwrap();
+
+        let table_name = "join_where_hash";
+        let key_prefix = "join_test:where_hash";
+        create_join_table(table_name, "field text, value text", "hash", key_prefix);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('field1', 'A'), ('field2', 'B'), ('field3', 'C');",
+            table_name
+        ))
+        .unwrap();
+
+        // JOIN + WHERE pushdown on the field column (valid pushdown for hash)
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_where_local l JOIN {} r ON l.id = r.field WHERE r.field = 'field1';",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 1, "Should match only field1 via pushdown");
+
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE field = 'field1';",
+            table_name
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE field = 'field2';",
+            table_name
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE field = 'field3';",
+            table_name
+        ))
+        .unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_where_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_left_join_null_padding() {
+        setup_join_fdw();
+
+        Spi::run("CREATE TEMPORARY TABLE join_left_local (id text, label text);").unwrap();
+        Spi::run("INSERT INTO join_left_local VALUES ('match', 'yes'), ('nomatch', 'no');")
+            .unwrap();
+
+        let table_name = "join_left_hash";
+        let key_prefix = "join_test:left_hash";
+        create_join_table(table_name, "field text, value text", "hash", key_prefix);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('match', 'found');",
+            table_name
+        ))
+        .unwrap();
+
+        let null_count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_left_local l LEFT JOIN {} r ON l.id = r.field WHERE r.field IS NULL;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            null_count, 1,
+            "One row should have NULL from unmatched LEFT JOIN"
+        );
+
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE field = 'match';",
+            table_name
+        ))
+        .unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_left_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_zset_on_member_column() {
+        setup_join_fdw();
+
+        // ZSet standard columns are (member text, score text) — member is column index 0
+        let zset_table = "join_zset_member";
+        let zset_key = "join_test:zset_member";
+        create_join_table(zset_table, "member text, score text", "zset", zset_key);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('player_a', 100), ('player_b', 200), ('player_c', 300);",
+            zset_table
+        ))
+        .unwrap();
+
+        // Local table to join on
+        Spi::run("CREATE TEMPORARY TABLE join_zset_local (name text, rank int);").unwrap();
+        Spi::run(
+            "INSERT INTO join_zset_local VALUES ('player_a', 1), ('player_b', 2), ('player_x', 3);",
+        )
+        .unwrap();
+
+        // JOIN on member (column 0 of zset) = name (column 0 of local)
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_zset_local l JOIN {} r ON l.name = r.member;",
+            zset_table
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 2, "Should match player_a and player_b");
+
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'player_a';",
+            zset_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'player_b';",
+            zset_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'player_c';",
+            zset_table
+        ))
+        .unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", zset_table));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_zset_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_fdw_hash_to_zset() {
+        setup_join_fdw();
+
+        let hash_table = "join_fdw_h2z_hash";
+        let zset_table = "join_fdw_h2z_zset";
+        let hash_key = "join_test:h2z_hash";
+        let zset_key = "join_test:h2z_zset";
+
+        create_join_table(hash_table, "field text, value text", "hash", hash_key);
+        create_join_table(zset_table, "member text, score text", "zset", zset_key);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('alpha', 'data_a'), ('beta', 'data_b'), ('gamma', 'data_g');",
+            hash_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('alpha', 10), ('beta', 20), ('delta', 30);",
+            zset_table
+        ))
+        .unwrap();
+
+        // FDW-to-FDW join: hash.field = zset.member (column 0 = column 0)
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM {} h JOIN {} z ON h.field = z.member;",
+            hash_table, zset_table
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            count, 2,
+            "FDW-to-FDW hash.field=zset.member should find alpha, beta"
+        );
+
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE field = 'alpha';",
+            hash_table
+        ))
+        .unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'beta';", hash_table)).unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE field = 'gamma';",
+            hash_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'alpha';",
+            zset_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'beta';",
+            zset_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'delta';",
+            zset_table
+        ))
+        .unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", hash_table));
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", zset_table));
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_empty_table() {
+        setup_join_fdw();
+
+        let table_name = "join_empty_hash";
+        let key_prefix = "join_test:empty_hash";
+        create_join_table(table_name, "field text, value text", "hash", key_prefix);
+
+        // Don't insert any data — table is empty
+
+        Spi::run("CREATE TEMPORARY TABLE join_empty_local (id text);").unwrap();
+        Spi::run("INSERT INTO join_empty_local VALUES ('a'), ('b');").unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_empty_local l JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 0, "JOIN with empty Redis table should return 0 rows");
+
+        let left_count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_empty_local l LEFT JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            left_count, 2,
+            "LEFT JOIN with empty Redis table should return all local rows"
+        );
+
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_empty_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_explain_output() {
+        setup_join_fdw();
+
+        let hash_table = "join_explain_hash";
+        let set_table = "join_explain_set";
+        let hash_key = "join_test:explain_hash";
+        let set_key = "join_test:explain_set";
+
+        create_join_table(hash_table, "field text, value text", "hash", hash_key);
+        create_join_table(set_table, "member text", "set", set_key);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('x', 'val_x');",
+            hash_table
+        ))
+        .unwrap();
+        Spi::run(&format!("INSERT INTO {} VALUES ('x');", set_table)).unwrap();
+
+        // Collect full EXPLAIN output across all rows
+        let explain_rows: Vec<String> = Spi::connect(|client| {
+            let mut rows = Vec::new();
+            let query = format!(
+                "EXPLAIN (FORMAT TEXT) SELECT * FROM {} h JOIN {} s ON h.field = s.member;",
+                hash_table, set_table
+            );
+            let tup_table = client.select(&query, None, &[]).unwrap();
+            for row in tup_table {
+                if let Some(line) = row.get::<String>(1).unwrap_or(None) {
+                    rows.push(line);
+                }
+            }
+            rows
+        });
+
+        let full_explain = explain_rows.join("\n");
+        log!("Full EXPLAIN output:\n{}", full_explain);
+
+        // Verify plan contains Foreign Scan (pushdown) on the join relation
+        let has_foreign_scan = full_explain.contains("Foreign Scan");
+        let has_nested_loop = full_explain.contains("Nested Loop");
+        assert!(
+            has_foreign_scan || has_nested_loop,
+            "EXPLAIN should show Foreign Scan (pushdown) or Nested Loop, got:\n{}",
+            full_explain
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'x';", hash_table)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'x';", set_table)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", hash_table));
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", set_table));
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_content_verification() {
+        setup_join_fdw();
+
+        let hash_table = "join_content_hash";
+        let hash_key = "join_test:content_hash";
+        create_join_table(hash_table, "field text, value text", "hash", hash_key);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('key1', 'hello'), ('key2', 'world');",
+            hash_table
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_content_local (id text, label text);").unwrap();
+        Spi::run("INSERT INTO join_content_local VALUES ('key1', 'first'), ('key2', 'second');")
+            .unwrap();
+
+        // Verify actual content of joined rows, not just count
+        let result = Spi::get_one::<String>(&format!(
+            "SELECT r.value FROM join_content_local l JOIN {} r ON l.id = r.field WHERE l.id = 'key1';",
+            hash_table
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(result, "hello", "JOIN should return correct value for key1");
+
+        let result2 = Spi::get_one::<String>(&format!(
+            "SELECT l.label FROM join_content_local l JOIN {} r ON l.id = r.field WHERE r.field = 'key2';",
+            hash_table
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            result2, "second",
+            "JOIN should return correct local column for key2"
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'key1';", hash_table)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'key2';", hash_table)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", hash_table));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_content_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_left_join_content_with_nulls() {
+        setup_join_fdw();
+
+        let hash_table = "join_nullcontent_hash";
+        let hash_key = "join_test:nullcontent_hash";
+        create_join_table(hash_table, "field text, value text", "hash", hash_key);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('a', 'found_a');",
+            hash_table
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_nullcontent_local (id text);").unwrap();
+        Spi::run("INSERT INTO join_nullcontent_local VALUES ('a'), ('missing');").unwrap();
+
+        // LEFT JOIN: 'missing' should produce NULL for the Redis side
+        let null_value = Spi::get_one::<String>(&format!(
+            "SELECT r.value FROM join_nullcontent_local l LEFT JOIN {} r ON l.id = r.field WHERE l.id = 'missing';",
+            hash_table
+        ))
+        .unwrap();
+
+        assert!(
+            null_value.is_none(),
+            "LEFT JOIN with no match should produce NULL, got: {:?}",
+            null_value
+        );
+
+        let found_value = Spi::get_one::<String>(&format!(
+            "SELECT r.value FROM join_nullcontent_local l LEFT JOIN {} r ON l.id = r.field WHERE l.id = 'a';",
+            hash_table
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            found_value, "found_a",
+            "LEFT JOIN with match should return the value"
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'a';", hash_table)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", hash_table));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_nullcontent_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_list_with_local_table() {
+        setup_join_fdw();
+
+        Spi::run("CREATE TEMPORARY TABLE join_list_local (val text);").unwrap();
+        Spi::run("INSERT INTO join_list_local VALUES ('item1'), ('item2'), ('missing');").unwrap();
+
+        let table_name = "join_list_test";
+        let key_prefix = "join_test:list_local";
+        create_join_table(table_name, "element text", "list", key_prefix);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('item1'), ('item2'), ('item3');",
+            table_name
+        ))
+        .unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_list_local l JOIN {} r ON l.val = r.element;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 2, "List JOIN should match item1 and item2");
+
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE element = 'item1';",
+            table_name
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE element = 'item2';",
+            table_name
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE element = 'item3';",
+            table_name
+        ))
+        .unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_list_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_string_with_local_table() {
+        setup_join_fdw();
+
+        // String type uses multi-key pattern (key*, with key column + value column)
+        let table_name = "join_string_test";
+        let key_prefix = "join_test:str:*";
+        create_join_table(table_name, "key text, value text", "string", key_prefix);
+
+        // Insert data directly via Redis commands using a helper hash table
+        // For string multi-key: first column is key name, second is value
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('join_test:str:alpha', 'val_alpha'), ('join_test:str:beta', 'val_beta');",
+            table_name
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_str_local (k text);").unwrap();
+        Spi::run(
+            "INSERT INTO join_str_local VALUES ('join_test:str:alpha'), ('join_test:str:gamma');",
+        )
+        .unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_str_local l JOIN {} r ON l.k = r.key;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 1, "String multi-key JOIN should match alpha only");
+
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE key = 'join_test:str:alpha';",
+            table_name
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE key = 'join_test:str:beta';",
+            table_name
+        ))
+        .unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_str_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_large_dataset() {
+        setup_join_fdw();
+
+        let table_name = "join_large_hash";
+        let key_prefix = "join_test:large_hash";
+        create_join_table(table_name, "field text, value text", "hash", key_prefix);
+
+        // Insert 100 rows to test moderate-scale join
+        let mut insert_sql = String::from("INSERT INTO ");
+        insert_sql.push_str(table_name);
+        insert_sql.push_str(" VALUES ");
+        for i in 0..100 {
+            if i > 0 {
+                insert_sql.push_str(", ");
+            }
+            insert_sql.push_str(&format!("('key{}', 'val{}')", i, i));
+        }
+        insert_sql.push(';');
+        Spi::run(&insert_sql).unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_large_local (id text);").unwrap();
+        let mut local_sql = String::from("INSERT INTO join_large_local VALUES ");
+        for i in 0..50 {
+            if i > 0 {
+                local_sql.push_str(", ");
+            }
+            local_sql.push_str(&format!("('key{}')", i * 2));
+        }
+        local_sql.push(';');
+        Spi::run(&local_sql).unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_large_local l JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 50, "Should match 50 even-numbered keys");
+
+        // Cleanup
+        for i in 0..100 {
+            Spi::run(&format!(
+                "DELETE FROM {} WHERE field = 'key{}';",
+                table_name, i
+            ))
+            .unwrap();
+        }
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_large_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_rescan_correctness() {
+        setup_join_fdw();
+
+        let table_name = "join_rescan_hash";
+        let key_prefix = "join_test:rescan_hash";
+        create_join_table(table_name, "field text, value text", "hash", key_prefix);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('a', 'val_a'), ('b', 'val_b');",
+            table_name
+        ))
+        .unwrap();
+
+        // Subquery that forces multiple rescans of the FDW table
+        Spi::run("CREATE TEMPORARY TABLE join_rescan_local (id text, grp int);").unwrap();
+        Spi::run("INSERT INTO join_rescan_local VALUES ('a', 1), ('b', 1), ('a', 2), ('b', 2);")
+            .unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_rescan_local l JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            count, 4,
+            "Rescan should correctly return results for duplicated local rows"
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'a';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'b';", table_name)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_rescan_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_right_join_fallback() {
+        setup_join_fdw();
+
+        let table_name = "join_right_hash";
+        let key_prefix = "join_test:right_hash";
+        create_join_table(table_name, "field text, value text", "hash", key_prefix);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('a', 'val_a'), ('b', 'val_b'), ('c', 'val_c');",
+            table_name
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_right_local (id text, label text);").unwrap();
+        Spi::run("INSERT INTO join_right_local VALUES ('a', 'L1'), ('b', 'L2'), ('d', 'L4');")
+            .unwrap();
+
+        // RIGHT JOIN: all local rows kept, Redis rows only where matched
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM {} r RIGHT JOIN join_right_local l ON r.field = l.id;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            count, 3,
+            "RIGHT JOIN should return all 3 local rows (a, b, d)"
+        );
+
+        // Verify unmatched Redis side produces NULL
+        let null_field = Spi::get_one::<String>(&format!(
+            "SELECT r.field FROM {} r RIGHT JOIN join_right_local l ON r.field = l.id WHERE l.id = 'd';",
+            table_name
+        ))
+        .unwrap();
+
+        assert!(
+            null_field.is_none(),
+            "RIGHT JOIN unmatched Redis row should be NULL, got: {:?}",
+            null_field
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'a';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'b';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'c';", table_name)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_right_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_cross_database_no_pushdown() {
+        setup_join_fdw();
+
+        // Create a second server pointing to a different database
+        let server2 = "redis_join_server_db2";
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '{}');",
+            server2, FDW_NAME, REDIS_HOST_PORT
+        ))
+        .unwrap();
+
+        let table1 = "join_crossdb_hash1";
+        let table2 = "join_crossdb_hash2";
+        let key1 = "join_test:crossdb_h1";
+        let key2 = "join_test:crossdb_h2";
+
+        // Table 1 on database 15 (default server)
+        create_join_table(table1, "field text, value text", "hash", key1);
+
+        // Table 2 on database 14 (different database via second server)
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {} (field text, value text) SERVER {} OPTIONS (
+                database '14',
+                table_type 'hash',
+                table_key_prefix '{}'
+            );",
+            table2, server2, key2
+        ))
+        .unwrap();
+
+        Spi::run(&format!("INSERT INTO {} VALUES ('x', 'val_x');", table1)).unwrap();
+        Spi::run(&format!("INSERT INTO {} VALUES ('x', 'val_x2');", table2)).unwrap();
+
+        // JOIN across different databases — should still work via nested-loop
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM {} t1 JOIN {} t2 ON t1.field = t2.field;",
+            table1, table2
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            count, 1,
+            "Cross-database JOIN should work via nested-loop fallback"
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'x';", table1)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'x';", table2)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table1));
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table2));
+        let _ = Spi::run(&format!("DROP SERVER IF EXISTS {} CASCADE;", server2));
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_fdw_to_fdw_left_join_null_handling() {
+        setup_join_fdw();
+
+        let hash_table = "join_fdw_null_hash";
+        let set_table = "join_fdw_null_set";
+        let hash_key = "join_test:fdw_null_hash";
+        let set_key = "join_test:fdw_null_set";
+
+        create_join_table(hash_table, "field text, value text", "hash", hash_key);
+        create_join_table(set_table, "member text", "set", set_key);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('match', 'found'), ('only_hash', 'orphan');",
+            hash_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('match'), ('only_set');",
+            set_table
+        ))
+        .unwrap();
+
+        // FDW-to-FDW LEFT JOIN: hash LEFT JOIN set ON hash.field = set.member
+        // 'match' should produce a row; 'only_hash' should produce NULL for set.member
+        let total = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM {} h LEFT JOIN {} s ON h.field = s.member;",
+            hash_table, set_table
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(total, 2, "LEFT JOIN should return both hash rows");
+
+        // Verify the unmatched row produces actual SQL NULL (not literal 'NULL')
+        let null_member = Spi::get_one::<String>(&format!(
+            "SELECT s.member FROM {} h LEFT JOIN {} s ON h.field = s.member WHERE h.field = 'only_hash';",
+            hash_table, set_table
+        ))
+        .unwrap();
+
+        assert!(
+            null_member.is_none(),
+            "Unmatched LEFT JOIN row should produce SQL NULL, got: {:?}",
+            null_member
+        );
+
+        // Verify matched row returns correct value
+        let matched = Spi::get_one::<String>(&format!(
+            "SELECT s.member FROM {} h LEFT JOIN {} s ON h.field = s.member WHERE h.field = 'match';",
+            hash_table, set_table
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(matched, "match", "Matched row should return correct member");
+
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE field = 'match';",
+            hash_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE field = 'only_hash';",
+            hash_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'match';",
+            set_table
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "DELETE FROM {} WHERE member = 'only_set';",
+            set_table
+        ))
+        .unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", hash_table));
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", set_table));
+        cleanup_join_fdw();
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -58,3 +58,9 @@ pub mod tls_tests;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub mod fdw_callbacks_tests;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod pool_performance_tests;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod join_tests;

--- a/src/tests/pool_performance_tests.rs
+++ b/src/tests/pool_performance_tests.rs
@@ -1,0 +1,208 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    const REDIS_HOST_PORT: &str = "127.0.0.1:8899";
+    const TEST_DATABASE: &str = "15";
+    const FDW_NAME: &str = "redis_pool_perf_wrapper";
+    const SERVER_NAME: &str = "redis_pool_perf_server";
+
+    fn setup_pool_test() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {} HANDLER redis_fdw_handler;",
+            FDW_NAME
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '{}');",
+            SERVER_NAME, FDW_NAME, REDIS_HOST_PORT
+        ))
+        .unwrap();
+    }
+
+    fn cleanup_pool_test() {
+        let _ = Spi::run(&format!("DROP SERVER IF EXISTS {} CASCADE;", SERVER_NAME));
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+    }
+
+    fn create_pool_test_table(table_name: &str, columns: &str, table_type: &str, key_prefix: &str) {
+        let sql = format!(
+            "CREATE FOREIGN TABLE {table_name} ({columns}) SERVER {SERVER_NAME} OPTIONS (
+                database '{TEST_DATABASE}',
+                table_type '{table_type}',
+                table_key_prefix '{key_prefix}'
+            );"
+        );
+        Spi::run(&sql).unwrap();
+    }
+
+    #[pg_test]
+    fn test_pool_real_cost_estimation() {
+        setup_pool_test();
+        let table_name = "pool_perf_hash_cost";
+        let key_prefix = "pool_perf:cost_test";
+
+        create_pool_test_table(table_name, "field text, value text", "hash", key_prefix);
+
+        for i in 0..5 {
+            Spi::run(&format!(
+                "INSERT INTO {} VALUES ('field{}', 'value{}');",
+                table_name, i, i
+            ))
+            .unwrap();
+        }
+
+        let explain_output = Spi::get_one::<String>(&format!(
+            "EXPLAIN (FORMAT TEXT) SELECT * FROM {};",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        log!("EXPLAIN output: {}", explain_output);
+        assert!(
+            !explain_output.contains("rows=1000"),
+            "Row estimate should not be the default 1000. Got: {}",
+            explain_output
+        );
+
+        for i in 0..5 {
+            Spi::run(&format!(
+                "DELETE FROM {} WHERE field = 'field{}';",
+                table_name, i
+            ))
+            .unwrap();
+        }
+
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        cleanup_pool_test();
+    }
+
+    #[pg_test]
+    fn test_pool_rescan_no_reconnect() {
+        setup_pool_test();
+        let table_name = "pool_perf_rescan";
+        let key_prefix = "pool_perf:rescan_test";
+
+        create_pool_test_table(table_name, "field text, value text", "hash", key_prefix);
+
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('a', 'val_a');",
+            table_name
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "INSERT INTO {} VALUES ('b', 'val_b');",
+            table_name
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE pool_local_test (id text);").unwrap();
+        Spi::run("INSERT INTO pool_local_test VALUES ('a'), ('b');").unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM pool_local_test l, {} r WHERE l.id = r.field;",
+            table_name
+        ))
+        .unwrap();
+
+        assert!(count.is_some());
+        assert!(
+            count.unwrap() >= 0,
+            "JOIN should succeed with connection reuse"
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'a';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'b';", table_name)).unwrap();
+
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS pool_local_test;");
+        cleanup_pool_test();
+    }
+
+    #[pg_test]
+    fn test_pool_reuse_across_queries() {
+        setup_pool_test();
+        let table_name = "pool_reuse_hash";
+        let key_prefix = "pool_perf:reuse_test";
+
+        create_pool_test_table(table_name, "field text, value text", "hash", key_prefix);
+
+        Spi::run(&format!("INSERT INTO {} VALUES ('k1', 'v1');", table_name)).unwrap();
+
+        // Run multiple sequential queries to the same table — pool should be reused
+        for i in 0..10 {
+            let count = Spi::get_one::<i64>(&format!("SELECT COUNT(*) FROM {};", table_name))
+                .unwrap()
+                .unwrap();
+            assert_eq!(count, 1, "Query {} should return 1 row", i);
+        }
+
+        // Run queries interleaved with inserts — pool connection returned and reacquired
+        for i in 0..5 {
+            Spi::run(&format!(
+                "INSERT INTO {} VALUES ('iter{}', 'val{}');",
+                table_name, i, i
+            ))
+            .unwrap();
+        }
+
+        let final_count = Spi::get_one::<i64>(&format!("SELECT COUNT(*) FROM {};", table_name))
+            .unwrap()
+            .unwrap();
+        assert_eq!(final_count, 6, "Should have 1 original + 5 new rows");
+
+        // Cleanup all inserted rows
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'k1';", table_name)).unwrap();
+        for i in 0..5 {
+            Spi::run(&format!(
+                "DELETE FROM {} WHERE field = 'iter{}';",
+                table_name, i
+            ))
+            .unwrap();
+        }
+
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        cleanup_pool_test();
+    }
+
+    #[pg_test]
+    fn test_pool_multiple_tables_same_server() {
+        setup_pool_test();
+        let table1 = "pool_multi_hash";
+        let table2 = "pool_multi_set";
+        let key1 = "pool_perf:multi_hash";
+        let key2 = "pool_perf:multi_set";
+
+        create_pool_test_table(table1, "field text, value text", "hash", key1);
+        create_pool_test_table(table2, "member text", "set", key2);
+
+        Spi::run(&format!("INSERT INTO {} VALUES ('f1', 'v1');", table1)).unwrap();
+        Spi::run(&format!("INSERT INTO {} VALUES ('member1');", table2)).unwrap();
+
+        let h_count = Spi::get_one::<i64>(&format!("SELECT COUNT(*) FROM {};", table1))
+            .unwrap()
+            .unwrap();
+        let s_count = Spi::get_one::<i64>(&format!("SELECT COUNT(*) FROM {};", table2))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(h_count, 1);
+        assert_eq!(s_count, 1);
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'f1';", table1)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'member1';", table2)).unwrap();
+
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table1));
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table2));
+        cleanup_pool_test();
+    }
+}

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -130,14 +130,58 @@ pub unsafe fn serialize_ptr_to_list(ptr: *mut c_void) -> *mut pg_sys::List {
     })
 }
 
+/// Serialize multiple i64 values to a PG List (for passing join info through fdw_private)
+pub unsafe fn serialize_join_info_to_list(values: &[i64]) -> *mut pg_sys::List {
+    memcx::current_context(|mcx| {
+        let mut ret = List::<*mut c_void>::Nil;
+        for &val in values {
+            let cst: *mut pg_sys::Const = pg_sys::makeConst(
+                pg_sys::INT8OID,
+                -1,
+                pg_sys::InvalidOid,
+                8,
+                val.into_datum().unwrap(),
+                false,
+                true,
+            );
+            ret.unstable_push_in_context(cst as _, mcx);
+        }
+        ret.into_ptr()
+    })
+}
+
 /// Deserialize a raw pointer from a PG List (for retrieving state from fdw_private)
 pub unsafe fn deserialize_ptr_from_list(list: *mut pg_sys::List) -> *mut c_void {
     memcx::current_context(|mcx| {
         if let Some(list) = List::<*mut c_void>::downcast_ptr_in_memcx(list, mcx) {
             if let Some(cst) = list.get(0) {
                 let cst = *(*cst as *mut pg_sys::Const);
-                let ptr = i64::from_datum(cst.constvalue, cst.constisnull).unwrap();
-                return ptr as *mut c_void;
+                if cst.constisnull {
+                    return std::ptr::null_mut();
+                }
+                match i64::from_datum(cst.constvalue, false) {
+                    Some(ptr) => return ptr as *mut c_void,
+                    None => return std::ptr::null_mut(),
+                }
+            }
+        }
+        std::ptr::null_mut()
+    })
+}
+
+/// Deserialize the Nth raw pointer from a PG List
+pub unsafe fn deserialize_nth_ptr_from_list(list: *mut pg_sys::List, n: usize) -> *mut c_void {
+    memcx::current_context(|mcx| {
+        if let Some(list) = List::<*mut c_void>::downcast_ptr_in_memcx(list, mcx) {
+            if let Some(cst) = list.get(n) {
+                let cst = *(*cst as *mut pg_sys::Const);
+                if cst.constisnull {
+                    return std::ptr::null_mut();
+                }
+                match i64::from_datum(cst.constvalue, false) {
+                    Some(ptr) => return ptr as *mut c_void,
+                    None => return std::ptr::null_mut(),
+                }
             }
         }
         std::ptr::null_mut()


### PR DESCRIPTION
* add join module with types, parameterized lookup, and foreign join
* parameterized paths for FDW-to-local JOINs, GetForeignJoinPaths for FDW-to-FDW pushdown, pool lifecycle fixes (connect at planning),documentation restructure plan, and integration test coverage.
* Introduces ParamLookupType enum for O(1) Redis lookups in parameterized paths, and RedisJoinState + execute_foreign_join for FDW-to-FDW joins.
* implement parameterized rescan for nested-loop joins
* re_scan_foreign_scan now checks is_parameterized mode and executes direct Redis lookups (HGET/SISMEMBER/etc) per outer row value. iterate_foreign_scan returns parameterized results.
* register GetForeignJoinPaths for FDW-to-FDW join pushdown
