### PR TITLE
Implement Redis Foreign Data Wrapper functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 **Feature-complete for all CRUD operations plus EXPLAIN, batch INSERT, TRUNCATE, IMPORT FOREIGN SCHEMA, ANALYZE, and COPY FROM.** All Redis types (String, Hash, List, Set, ZSet) support SELECT, INSERT, UPDATE, DELETE, TRUNCATE. Stream supports SELECT, INSERT, DELETE, TRUNCATE only (append-only by design).
 
 ### Recent Work
+- Column validation: `validate_column_count()` enforces per-type column constraints at first query time (string=1, hash=2, list=1-2, set=1, zset=2, stream=2+)
+- Parameterized JOIN paths: `get_foreign_paths` advertises O(1) point-lookup paths for FDW-to-local JOINs (HGET, SISMEMBER, ZSCORE)
 - JOIN support: FDW-to-FDW join pushdown for same-server tables with automatic join column detection from query clauses
 - Connection pool optimization: planning phase now connects to Redis for real cardinality statistics
 - FDW lifecycle refactoring: batch insert logic moved to `state_manager.batch_insert_data()`; handlers is now a thin dispatch layer
@@ -34,7 +36,7 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 
 ### Known Issues
 - Cluster integration tests (9 tests) fail without Redis Cluster infrastructure running
-- All non-cluster tests pass (including 16 JOIN tests and 4 pool performance tests)
+- All non-cluster tests pass (including 23 JOIN tests, 16 column validation tests, and 4 pool performance tests)
 
 ## How to Work on This Project
 
@@ -67,12 +69,16 @@ make setup-redis
 # Run join-specific tests
 cargo pgrx test pg16 join_tests
 
+# Run column validation tests
+cargo pgrx test pg16 column_validation_tests
+
 # Run pool performance tests
 cargo pgrx test pg16 pool_performance
 ```
 
 JOIN tests create temporary local tables + Redis foreign tables and verify:
 - FDW-to-local INNER/LEFT JOINs return correct row counts
+- FDW-to-local parameterized path point-lookups (HGET/SISMEMBER/ZSCORE)
 - FDW-to-FDW same-server joins work with automatic column detection
 - Cross-type FDW-to-FDW joins (e.g., hash.field = zset.member)
 - JOIN + WHERE pushdown combinations
@@ -95,14 +101,20 @@ JOIN tests create temporary local tables + Redis foreign tables and verify:
 1. If it's a new Redis operation, implement it on `RedisTableOperations` trait in `src/tables/interface.rs`
 2. Add implementation for each type in `src/tables/implementations/{type}.rs`
 3. Add dispatch in `src/tables/types.rs` (use existing macro pattern)
-4. Wire the FDW callback in `src/core/handlers.rs`
-5. Add state management method in `src/core/state_manager.rs` if needed
-6. Add tests in `src/tests/`
+4. Wire the FDW callback in `src/core/handlers.rs` (registration) — implementation logic goes in the appropriate submodule (`join_handlers.rs`, `explain.rs`, `schema_import.rs`, `truncate.rs`)
+5. Shared column/TTL utilities go in `src/core/column_utils.rs`
+6. Add state management method in `src/core/state_manager.rs` if needed
+7. Add tests in `src/tests/`
 
 ### Key Files to Understand First
 | File | Purpose |
 |------|---------|
-| `src/core/handlers.rs` | All PostgreSQL FDW callbacks — the entry point for everything |
+| `src/core/handlers.rs` | FDW callback registration + core scan/modify flow |
+| `src/core/join_handlers.rs` | Join pushdown: parameterized paths, FDW-to-FDW join planning/execution |
+| `src/core/explain.rs` | EXPLAIN output for scan and modify operations |
+| `src/core/schema_import.rs` | IMPORT FOREIGN SCHEMA + ANALYZE + acquire_sample_rows |
+| `src/core/truncate.rs` | TRUNCATE implementation (UNLINK / SCAN+UNLINK) |
+| `src/core/column_utils.rs` | Shared utilities: TTL detection, column validation, data transformation |
 | `src/core/validator.rs` | DDL-time option validation (VALIDATOR function) |
 | `src/tables/interface.rs` | The `RedisTableOperations` trait — defines what each type must implement |
 | `src/tables/types.rs` | `RedisTableType` enum + dispatch methods |
@@ -114,7 +126,7 @@ JOIN tests create temporary local tables + Redis foreign tables and verify:
 PostgreSQL Query
     │
     ▼
-FDW Callbacks (handlers.rs)
+FDW Callbacks (handlers.rs — registration + core scan/modify)
     │
     ├── Planning: get_foreign_rel_size → get_foreign_paths → get_foreign_plan
     │       └── cost_estimation.rs, pushdown.rs
@@ -122,7 +134,7 @@ FDW Callbacks (handlers.rs)
     ├── Scanning: begin_foreign_scan → iterate → recheck → shutdown → end_foreign_scan
     │       └── state_manager.rs → RedisTableType dispatch → implementations/*
     │
-    ├── Explain: explain_foreign_scan, explain_foreign_modify
+    ├── Explain (explain.rs): explain_foreign_scan, explain_foreign_modify
     │       └── Reports server, key, type, pushdown, batch size, rows fetched
     │
     ├── Modify: begin_foreign_modify → exec_foreign_{insert,update,delete}
@@ -134,20 +146,22 @@ FDW Callbacks (handlers.rs)
     ├── Batch Insert: get_foreign_modify_batch_size → exec_foreign_batch_insert
     │       └── state_manager.batch_insert_data() — pipelines rows into Redis
     │
-    ├── Truncate: exec_foreign_truncate
+    ├── Truncate (truncate.rs): exec_foreign_truncate
     │       └── UNLINK (single-key) or SCAN+UNLINK (multi-key pattern)
     │
-    ├── Import Schema: import_foreign_schema
+    ├── Import Schema (schema_import.rs): import_foreign_schema
     │       └── SCAN → TYPE pipeline → group by prefix → generate DDL
     │
-    ├── Analyze: analyze_foreign_table → acquire_sample_rows
+    ├── Analyze (schema_import.rs): analyze_foreign_table → acquire_sample_rows
     │       └── Enables ANALYZE for query planning (HLEN/SCARD/ZCARD/XLEN + sampling)
     │
-    └── Join Pushdown: get_foreign_join_paths → plan_foreign_join → begin_foreign_join_scan
-            └── Same-server detection → hash-join execution (build/probe) → iterate results
-                    │
-                    ▼
-              Redis (via R2D2 pool_manager.rs)
+    ├── Join Pushdown (join_handlers.rs): get_foreign_join_paths → plan_foreign_join → begin_foreign_join_scan
+    │       └── Same-server detection → hash-join execution (build/probe) → iterate results
+    │
+    └── Column Utilities (column_utils.rs): TTL detection, column validation, data transformation
+            │
+            ▼
+      Redis (via R2D2 pool_manager.rs)
 ```
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ cargo fmt
 ## Key Architecture
 
 ### Module Structure
-- `src/core/` — FDW handler callbacks (`handlers.rs`), state management (`state_manager.rs`), connection pool (`pool_manager.rs`), connection factory (`connection_factory.rs`), DDL validator (`validator.rs`)
+- `src/core/` — FDW handler callbacks (`handlers.rs`), join pushdown logic (`join_handlers.rs`), EXPLAIN output (`explain.rs`), schema import & analyze (`schema_import.rs`), truncate (`truncate.rs`), shared column/TTL utilities (`column_utils.rs`), state management (`state_manager.rs`), connection pool (`pool_manager.rs`), connection factory (`connection_factory.rs`), DDL validator (`validator.rs`)
 - `src/tables/` — Trait interface (`interface.rs`), type enum + dispatch (`types.rs`, `macros.rs`), per-type implementations in `implementations/`
 - `src/query/` — WHERE pushdown (`pushdown.rs`), cost estimation (`cost_estimation.rs`), LIMIT handling (`limit.rs`), scan ops (`scan_ops.rs`)
 - `src/join/` — JOIN support: FDW-to-FDW pushdown (`foreign_join.rs`), types (`types.rs`)
@@ -98,8 +98,17 @@ Stream is append-only; UPDATE returns an error at the trait level and `IsForeign
 - First column is always the Redis key name
 - INSERT routes to specific key (first column); DELETE uses `DEL` on the full key
 
+### Column Validation
+- `validate_column_count()` in handlers.rs enforces per-type column constraints at first query time
+- Called from both `begin_foreign_scan` and `begin_foreign_modify`
+- Column count excludes the TTL column (detected by name "ttl")
+- Multi-key mode adds +1 expected column for the key prefix
+- Constraints: string=1, hash=2, list=1-2, set=1, zset=2, stream=2+
+- Error format: `redis_fdw: table type '{type}' requires {N} data column(s), got {M}`
+
 ### JOIN Architecture
-- **FDW-to-Local**: Standard nested-loop; PostgreSQL drives outer rows, FDW rescans inner on each iteration
+- **FDW-to-Local (parameterized)**: `get_foreign_paths` advertises cheap parameterized paths for point-lookup columns (hash/field→HGET, set/member→SISMEMBER, zset/member→ZSCORE). PostgreSQL's planner picks these for NestLoop joins, passing the outer row's value as a parameter. `iterate_foreign_scan` evaluates the expression and does a single-key Redis lookup per outer row.
+- **FDW-to-Local (fallback)**: If no parameterized path applies, standard nested-loop with full rescan on each iteration
 - **FDW-to-FDW**: `GetForeignJoinPaths` detects same-server tables, extracts join columns from restrictlist, creates pushdown join path
 - **Pushdown guards**: same server (host_port match), non-multi-key tables, non-Stream tables, merge-joinable (equality) operator, INNER/LEFT only, no base restrictions on either relation
 - **Base restriction guard**: If either relation has `baserestrictinfo` (WHERE clauses on individual tables), pushdown is skipped and PostgreSQL falls back to nested-loop which handles base quals correctly

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A high-performance Redis Foreign Data Wrapper (FDW) for PostgreSQL written in Ru
 - **WHERE pushdown**: Conditions executed directly in Redis (HGET/HMGET, SISMEMBER, etc.)
 - **TTL support**: Table-level default + per-row override via virtual `ttl` column
 - **Multi-key patterns**: Glob patterns (`*`, `?`, `[`) in `table_key_prefix` to query multiple keys
-- **DDL validation**: Option validator checks all options at CREATE time
+- **DDL validation**: Option validator checks all options at CREATE time; column count validated at query time
+- **Parameterized JOINs**: Point-lookup optimization for FDW-to-local JOINs (HGET, SISMEMBER, ZSCORE)
 - **Stream pagination**: Configurable batch processing for large data sets
 - **EXPLAIN support**: Detailed scan/modify metadata (server, key, pushdown, batch size)
 - **Batch INSERT**: Pipelined multi-row inserts via `ExecForeignBatchInsert` (configurable `batch_size`)
@@ -152,6 +153,23 @@ SERVER redis_server OPTIONS (table_type 'zset', table_key_prefix 'leaderboard');
 CREATE FOREIGN TABLE redis_stream (stream_id TEXT, event_type TEXT, event_data TEXT)
 SERVER redis_server OPTIONS (table_type 'stream', table_key_prefix 'events');
 ```
+
+### Column Constraints
+
+Each Redis type enforces a specific number of data columns. The FDW validates this at first query time and raises a clear error if the table definition is invalid:
+
+| Type    | Min Cols | Max Cols | Expected Columns                      |
+|---------|----------|----------|---------------------------------------|
+| string  | 1        | 1        | `value`                               |
+| hash    | 2        | 2        | `field, value`                        |
+| list    | 1        | 2        | `element` or `index, element`         |
+| set     | 1        | 1        | `member`                              |
+| zset    | 2        | 2        | `member, score`                       |
+| stream  | 2        | ∞        | `stream_id, field1[, field2, ...]`    |
+
+- **Multi-key mode** (`table_key_prefix` with glob): adds +1 for the key column (first column)
+- **TTL column**: an optional `ttl bigint` column is automatically excluded from validation
+- Validation occurs in `begin_foreign_scan` / `begin_foreign_modify` (first SELECT/INSERT/UPDATE/DELETE)
 
 ### Operations
 
@@ -434,7 +452,7 @@ redis_fdw_rs=#  SELECT * FROM user_profiles where key like '555%';
 
 ### FDW-to-Local Table JOINs
 
-Redis foreign tables can be joined with regular PostgreSQL tables using standard nested-loop plans:
+Redis foreign tables can be joined with regular PostgreSQL tables. The FDW advertises parameterized paths for point-lookup columns, enabling O(1) per-row lookups instead of full rescans:
 
 ```sql
 SELECT u.name, r.value
@@ -442,7 +460,13 @@ FROM users u
 JOIN redis_hash_table r ON u.key = r.field;
 ```
 
-The FDW provides accurate cardinality estimates to PostgreSQL's planner, enabling optimal join strategy selection. Each outer row triggers a full rescan of the Redis table.
+**Parameterized path support** (O(1) per outer row):
+- Hash: join on `field` column → HGET
+- Set: join on `member` column → SISMEMBER
+- ZSet: join on `member` column → ZSCORE
+- String (multi-key): join on `key` column → GET
+
+When the planner cannot use a parameterized path (e.g., join on a non-lookup column), it falls back to the standard nested-loop with full rescan.
 
 ### FDW-to-FDW JOINs (Same Server Pushdown)
 

--- a/src/core/column_utils.rs
+++ b/src/core/column_utils.rs
@@ -70,6 +70,9 @@ pub(crate) unsafe fn datum_to_text_string(
         let mut is_varlena = false;
         pg_sys::getTypeOutputInfo(typoid, &mut out_func_oid, &mut is_varlena);
         let cstr = pg_sys::OidOutputFunctionCall(out_func_oid, datum);
+        if cstr.is_null() {
+            return String::new();
+        }
         let result = std::ffi::CStr::from_ptr(cstr)
             .to_string_lossy()
             .into_owned();

--- a/src/core/column_utils.rs
+++ b/src/core/column_utils.rs
@@ -42,23 +42,40 @@ pub(crate) unsafe fn extract_column_names(tupdesc: pg_sys::TupleDesc) -> Vec<Str
 
 pub(crate) unsafe fn datum_to_text_string(
     datum: pg_sys::Datum,
-    _col_idx: usize,
-    _tupdesc: pg_sys::TupleDesc,
+    col_idx: usize,
+    tupdesc: pg_sys::TupleDesc,
 ) -> String {
-    let text_ptr = datum.cast_mut_ptr::<pg_sys::varlena>();
-    if text_ptr.is_null() {
-        return String::new();
+    use crate::utils::helpers::tuple_desc_attr;
+
+    let attr = tuple_desc_attr(tupdesc, col_idx);
+    let typoid = (*attr).atttypid;
+
+    if typoid == pg_sys::TEXTOID || typoid == pg_sys::VARCHAROID || typoid == pg_sys::BPCHAROID {
+        let text_ptr = datum.cast_mut_ptr::<pg_sys::varlena>();
+        if text_ptr.is_null() {
+            return String::new();
+        }
+        let detoasted = pg_sys::pg_detoast_datum_packed(text_ptr);
+        let cstr = pg_sys::text_to_cstring(detoasted);
+        let result = std::ffi::CStr::from_ptr(cstr)
+            .to_string_lossy()
+            .into_owned();
+        pg_sys::pfree(cstr as *mut std::ffi::c_void);
+        if detoasted != text_ptr {
+            pg_sys::pfree(detoasted as *mut std::ffi::c_void);
+        }
+        result
+    } else {
+        let mut out_func_oid: pg_sys::Oid = pg_sys::InvalidOid;
+        let mut is_varlena = false;
+        pg_sys::getTypeOutputInfo(typoid, &mut out_func_oid, &mut is_varlena);
+        let cstr = pg_sys::OidOutputFunctionCall(out_func_oid, datum);
+        let result = std::ffi::CStr::from_ptr(cstr)
+            .to_string_lossy()
+            .into_owned();
+        pg_sys::pfree(cstr as *mut std::ffi::c_void);
+        result
     }
-    let detoasted = pg_sys::pg_detoast_datum_packed(text_ptr);
-    let cstr = pg_sys::text_to_cstring(detoasted);
-    let result = std::ffi::CStr::from_ptr(cstr)
-        .to_string_lossy()
-        .into_owned();
-    pg_sys::pfree(cstr as *mut std::ffi::c_void);
-    if detoasted != text_ptr {
-        pg_sys::pfree(detoasted as *mut std::ffi::c_void);
-    }
-    result
 }
 
 pub(crate) fn validate_column_count(

--- a/src/core/column_utils.rs
+++ b/src/core/column_utils.rs
@@ -1,0 +1,156 @@
+use crate::{core::state_manager::RedisFdwState, tables::types::RedisTableType};
+use pgrx::prelude::*;
+
+#[inline]
+pub(crate) unsafe fn state_from_ptr<'a>(ptr: *mut std::os::raw::c_void) -> &'a mut RedisFdwState {
+    if ptr.is_null() {
+        pgrx::error!("Redis FDW state pointer is null");
+    }
+    &mut *(ptr as *mut RedisFdwState)
+}
+
+pub(crate) unsafe fn detect_ttl_column(tupdesc: pg_sys::TupleDesc) -> Option<usize> {
+    use crate::utils::helpers::tuple_desc_attr;
+    let natts = (*tupdesc).natts as usize;
+    for i in 0..natts {
+        let attr = tuple_desc_attr(tupdesc, i);
+        if (*attr).attisdropped {
+            continue;
+        }
+        let name = pgrx::name_data_to_str(&(*attr).attname);
+        if name.eq_ignore_ascii_case("ttl") {
+            return Some(i);
+        }
+    }
+    None
+}
+
+pub(crate) unsafe fn extract_column_names(tupdesc: pg_sys::TupleDesc) -> Vec<String> {
+    use crate::utils::helpers::tuple_desc_attr;
+    let natts = (*tupdesc).natts as usize;
+    let mut names = Vec::with_capacity(natts);
+    for i in 0..natts {
+        let attr = tuple_desc_attr(tupdesc, i);
+        if (*attr).attisdropped {
+            continue;
+        }
+        let name = pgrx::name_data_to_str(&(*attr).attname);
+        names.push(name.to_string());
+    }
+    names
+}
+
+pub(crate) unsafe fn datum_to_text_string(
+    datum: pg_sys::Datum,
+    _col_idx: usize,
+    _tupdesc: pg_sys::TupleDesc,
+) -> String {
+    let text_ptr = datum.cast_mut_ptr::<pg_sys::varlena>();
+    if text_ptr.is_null() {
+        return String::new();
+    }
+    let detoasted = pg_sys::pg_detoast_datum_packed(text_ptr);
+    let cstr = pg_sys::text_to_cstring(detoasted);
+    let result = std::ffi::CStr::from_ptr(cstr)
+        .to_string_lossy()
+        .into_owned();
+    pg_sys::pfree(cstr as *mut std::ffi::c_void);
+    if detoasted != text_ptr {
+        pg_sys::pfree(detoasted as *mut std::ffi::c_void);
+    }
+    result
+}
+
+pub(crate) fn validate_column_count(
+    table_type: &RedisTableType,
+    column_count: usize,
+    is_multi_key: bool,
+) {
+    let extra = if is_multi_key { 1 } else { 0 };
+    let (min_cols, max_cols, type_name, expected_desc) = match table_type {
+        RedisTableType::String(_) => (1 + extra, 1 + extra, "string", "value"),
+        RedisTableType::Hash(_) => (2 + extra, 2 + extra, "hash", "field, value"),
+        RedisTableType::List(_) => (1 + extra, 2 + extra, "list", "element [, index]"),
+        RedisTableType::Set(_) => (1 + extra, 1 + extra, "set", "member"),
+        RedisTableType::ZSet(_) => (2 + extra, 2 + extra, "zset", "member, score"),
+        RedisTableType::Stream(_) => (2, usize::MAX, "stream", "stream_id, field1[, ...]"),
+        RedisTableType::None => return,
+    };
+
+    if column_count < min_cols || column_count > max_cols {
+        let multi_key_note = if is_multi_key {
+            " (including key column for multi-key mode)"
+        } else {
+            ""
+        };
+        if min_cols == max_cols {
+            pgrx::error!(
+                "redis_fdw: table type '{}' requires exactly {} data column(s) ({}){}, but foreign table has {}. \
+                 Exclude the optional 'ttl' column from this count.",
+                type_name,
+                min_cols,
+                expected_desc,
+                multi_key_note,
+                column_count
+            );
+        } else {
+            pgrx::error!(
+                "redis_fdw: table type '{}' requires {}-{} data column(s) ({}){}, but foreign table has {}. \
+                 Exclude the optional 'ttl' column from this count.",
+                type_name,
+                min_cols,
+                max_cols,
+                expected_desc,
+                multi_key_note,
+                column_count
+            );
+        }
+    }
+}
+
+pub(crate) fn transform_insert_data(
+    table_type: &RedisTableType,
+    column_names: &[String],
+    data: Vec<String>,
+) -> Vec<String> {
+    match table_type {
+        RedisTableType::List(_) if column_names.len() >= 2 => data.into_iter().skip(1).collect(),
+        RedisTableType::Stream(_) if column_names.len() > 1 => {
+            let mut stream_data = Vec::with_capacity(1 + (data.len() - 1) * 2);
+            stream_data.push(data[0].clone());
+            for (i, val) in data[1..].iter().enumerate() {
+                if let Some(col_name) = column_names.get(i + 1) {
+                    stream_data.push(col_name.clone());
+                    stream_data.push(val.clone());
+                }
+            }
+            stream_data
+        }
+        _ => data,
+    }
+}
+
+pub(crate) unsafe fn extract_delete_key(
+    state: &RedisFdwState,
+    plan_slot: *mut pgrx::pg_sys::TupleTableSlot,
+) -> Result<String, &'static str> {
+    use crate::utils::helpers::exec_get_junk_attribute;
+
+    if state.key_attno <= 0 {
+        return Err("Invalid key attribute number");
+    }
+
+    let mut is_null = false;
+    let datum = exec_get_junk_attribute(plan_slot, state.key_attno, &mut is_null);
+
+    match String::from_datum(datum, is_null) {
+        Some(key_string) => {
+            if key_string.is_empty() {
+                Err("Delete key is empty")
+            } else {
+                Ok(key_string)
+            }
+        }
+        None => Err("Failed to convert datum to string"),
+    }
+}

--- a/src/core/column_utils.rs
+++ b/src/core/column_utils.rs
@@ -110,6 +110,16 @@ pub(crate) fn validate_column_count(
                 multi_key_note,
                 column_count
             );
+        } else if max_cols == usize::MAX {
+            pgrx::error!(
+                "redis_fdw: table type '{}' requires at least {} data column(s) ({}){}, but foreign table has {}. \
+                 Exclude the optional 'ttl' column from this count.",
+                type_name,
+                min_cols,
+                expected_desc,
+                multi_key_note,
+                column_count
+            );
         } else {
             pgrx::error!(
                 "redis_fdw: table type '{}' requires {}-{} data column(s) ({}){}, but foreign table has {}. \

--- a/src/core/explain.rs
+++ b/src/core/explain.rs
@@ -1,0 +1,122 @@
+use crate::core::state_manager::RedisFdwState;
+use pgrx::prelude::*;
+use std::ffi::CString;
+
+#[pg_guard]
+pub(crate) unsafe extern "C-unwind" fn explain_foreign_scan(
+    node: *mut pg_sys::ForeignScanState,
+    es: *mut pg_sys::ExplainState,
+) {
+    log!("---> explain_foreign_scan");
+    let fdw_state = (*node).fdw_state as *mut RedisFdwState;
+    if fdw_state.is_null() {
+        return;
+    }
+    let state = &*fdw_state;
+
+    if state.is_join_scan {
+        let label_join = c"Redis Join";
+        let join_desc = if let Some(ref js) = state.join_state {
+            format!(
+                "{}({}) x {}({})",
+                js.outer_table_type.redis_type_name(),
+                js.outer_key_prefix,
+                js.inner_table_type.redis_type_name(),
+                js.inner_key_prefix
+            )
+        } else {
+            "FDW-to-FDW pushdown".to_string()
+        };
+        let join_cstr = CString::new(join_desc).unwrap_or_default();
+        pg_sys::ExplainPropertyText(label_join.as_ptr(), join_cstr.as_ptr(), es);
+
+        let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
+        let label_server = c"Redis Server";
+        pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
+        return;
+    }
+
+    let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
+    let key_cstr = CString::new(state.table_key_prefix.as_str()).unwrap_or_default();
+    let type_name = state.table_type.redis_type_name();
+    let type_cstr = CString::new(type_name).unwrap_or_default();
+    let multi_key_cstr =
+        CString::new(if state.is_multi_key { "true" } else { "false" }).unwrap_or_default();
+
+    let label_server = c"Redis Server";
+    let label_key = c"Redis Key";
+    let label_type = c"Table Type";
+    let label_multi = c"Multi-Key Mode";
+    let label_pushdown = c"Pushdown";
+    let label_batch = c"Batch Size";
+
+    pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_key.as_ptr(), key_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_type.as_ptr(), type_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_multi.as_ptr(), multi_key_cstr.as_ptr(), es);
+
+    let pushdown_desc = if let Some(ref analysis) = state.pushdown_analysis {
+        if analysis.has_optimizations() {
+            analysis
+                .pushable_conditions
+                .iter()
+                .map(|c| format!("{} {} '{}'", c.column_name, c.operator, c.value))
+                .collect::<Vec<_>>()
+                .join(", ")
+        } else {
+            "none".to_string()
+        }
+    } else {
+        "none".to_string()
+    };
+    let pushdown_cstr = CString::new(pushdown_desc).unwrap_or_default();
+    pg_sys::ExplainPropertyText(label_pushdown.as_ptr(), pushdown_cstr.as_ptr(), es);
+
+    let label_batch_unit = c"rows";
+    pg_sys::ExplainPropertyInteger(
+        label_batch.as_ptr(),
+        label_batch_unit.as_ptr(),
+        state.batch_size as i64,
+        es,
+    );
+
+    if (*es).analyze {
+        let label_rows = c"Rows Fetched";
+        let label_rows_unit = c"rows";
+        pg_sys::ExplainPropertyInteger(
+            label_rows.as_ptr(),
+            label_rows_unit.as_ptr(),
+            state.row_count as i64,
+            es,
+        );
+    }
+}
+
+#[pg_guard]
+pub(crate) unsafe extern "C-unwind" fn explain_foreign_modify(
+    _mtstate: *mut pg_sys::ModifyTableState,
+    rinfo: *mut pg_sys::ResultRelInfo,
+    _fdw_private: *mut pg_sys::List,
+    _subplan_index: ::core::ffi::c_int,
+    es: *mut pg_sys::ExplainState,
+) {
+    log!("---> explain_foreign_modify");
+    let fdw_state = (*rinfo).ri_FdwState as *mut RedisFdwState;
+    if fdw_state.is_null() {
+        return;
+    }
+    let state = &*fdw_state;
+
+    let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
+    let key_cstr = CString::new(state.table_key_prefix.as_str()).unwrap_or_default();
+    let type_name = state.table_type.redis_type_name();
+    let type_cstr = CString::new(type_name).unwrap_or_default();
+
+    let label_server = c"Redis Server";
+    let label_key = c"Redis Key";
+    let label_type = c"Table Type";
+
+    pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_key.as_ptr(), key_cstr.as_ptr(), es);
+    pg_sys::ExplainPropertyText(label_type.as_ptr(), type_cstr.as_ptr(), es);
+}

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -1,9 +1,19 @@
 use crate::{
-    core::state_manager::RedisFdwState,
-    join::{
-        foreign_join::execute_foreign_join,
-        types::{RedisJoinState, RedisJoinType},
+    core::{
+        column_utils::{
+            datum_to_text_string, detect_ttl_column, extract_column_names, extract_delete_key,
+            state_from_ptr, transform_insert_data, validate_column_count,
+        },
+        explain::{explain_foreign_modify, explain_foreign_scan},
+        join::{
+            add_parameterized_paths, begin_foreign_join_scan, get_foreign_join_paths,
+            plan_foreign_join,
+        },
+        schema_import::{analyze_foreign_table, import_foreign_schema},
+        state_manager::RedisFdwState,
+        truncate::exec_foreign_truncate,
     },
+    join::foreign_join::execute_foreign_join,
     query::{limit::extract_limit_offset_info, pushdown::WhereClausePushdown},
     tables::types::RedisTableType,
     utils::{helpers::*, memory::create_wrappers_memctx, row::Row},
@@ -13,73 +23,7 @@ use pgrx::{
     prelude::*,
     PgMemoryContexts, PgRelation,
 };
-use std::ffi::CString;
 use std::ptr;
-
-#[inline]
-unsafe fn state_from_ptr<'a>(ptr: *mut std::os::raw::c_void) -> &'a mut RedisFdwState {
-    if ptr.is_null() {
-        pgrx::error!("Redis FDW state pointer is null");
-    }
-    &mut *(ptr as *mut RedisFdwState)
-}
-
-unsafe fn detect_ttl_column(tupdesc: pg_sys::TupleDesc) -> Option<usize> {
-    let natts = (*tupdesc).natts as usize;
-    for i in 0..natts {
-        let attr = tuple_desc_attr(tupdesc, i);
-        if (*attr).attisdropped {
-            continue;
-        }
-        let name = pgrx::name_data_to_str(&(*attr).attname);
-        if name.eq_ignore_ascii_case("ttl") {
-            return Some(i);
-        }
-    }
-    None
-}
-
-unsafe fn extract_column_names(tupdesc: pg_sys::TupleDesc) -> Vec<String> {
-    let natts = (*tupdesc).natts as usize;
-    let mut names = Vec::with_capacity(natts);
-    for i in 0..natts {
-        let attr = tuple_desc_attr(tupdesc, i);
-        if (*attr).attisdropped {
-            continue;
-        }
-        let name = pgrx::name_data_to_str(&(*attr).attname);
-        names.push(name.to_string());
-    }
-    names
-}
-
-fn transform_insert_data(
-    table_type: &RedisTableType,
-    column_names: &[String],
-    data: Vec<String>,
-) -> Vec<String> {
-    match table_type {
-        RedisTableType::List(_) if column_names.len() >= 2 => {
-            // List with index column: strip the index (first element)
-            data.into_iter().skip(1).collect()
-        }
-        RedisTableType::Stream(_) if column_names.len() > 1 => {
-            // Stream: interleave column names with values
-            // Input: [id, val1, val2, val3]
-            // Output: [id, col_name_1, val1, col_name_2, val2, ...]
-            let mut stream_data = Vec::with_capacity(1 + (data.len() - 1) * 2);
-            stream_data.push(data[0].clone());
-            for (i, val) in data[1..].iter().enumerate() {
-                if let Some(col_name) = column_names.get(i + 1) {
-                    stream_data.push(col_name.clone());
-                    stream_data.push(val.clone());
-                }
-            }
-            stream_data
-        }
-        _ => data,
-    }
-}
 
 const REDISMODY: &str = "__redis_UD_key_name";
 
@@ -156,17 +100,14 @@ extern "C-unwind" fn get_foreign_rel_size(
         let ctx = create_wrappers_memctx(&ctx_name);
         let mut state = RedisFdwState::new(ctx);
 
-        // Initialize the state with table options for pushdown analysis
         let options = get_foreign_table_options(foreigntableid);
         log!("Foreign table options: {:?}", options);
         state.update_from_options(options);
 
-        // Set table type so pushdown analysis knows what optimizations are possible
         if let Some(table_type_str) = state.opts.get("table_type") {
             state.table_type = RedisTableType::from_str(table_type_str);
         }
 
-        // Connect to Redis for real statistics gathering
         if let Err(e) = state.init_redis_connection_from_options() {
             log!(
                 "Could not connect to Redis for cost estimation, using defaults: {}",
@@ -174,7 +115,6 @@ extern "C-unwind" fn get_foreign_rel_size(
             );
         }
 
-        // Calculate cost estimate using actual Redis statistics
         let cost_estimate = state.estimate_costs();
         log!(
             "Cost estimation: rows={}, startup_cost={}, total_cost={}, width={}",
@@ -184,14 +124,11 @@ extern "C-unwind" fn get_foreign_rel_size(
             cost_estimate.width
         );
 
-        // Release planning-phase connection back to pool immediately, begin_foreign_scan will re-acquire from pool (fast path: read-lock only).
         state.redis_connection = None;
 
-        // Store the estimate for use in get_foreign_paths
         let estimated_rows = cost_estimate.rows;
         state.cost_estimate = Some(cost_estimate);
 
-        // Allocate state in PG memory context — Drop fires on context destruction (longjmp-safe)
         let state_ptr = PgMemoryContexts::For(ctx).leak_and_drop_on_delete(state);
         (*baserel).fdw_private = state_ptr as *mut std::os::raw::c_void;
         (*baserel).rows = estimated_rows;
@@ -206,7 +143,6 @@ extern "C-unwind" fn get_foreign_paths(
 ) {
     log!("---> get_foreign_paths");
     unsafe {
-        // Retrieve cost estimate from state (calculated in get_foreign_rel_size)
         let state_ptr = (*baserel).fdw_private as *mut RedisFdwState;
         let (startup_cost, total_cost) = if !state_ptr.is_null() {
             let state = &*state_ptr;
@@ -218,12 +154,10 @@ extern "C-unwind" fn get_foreign_paths(
                 );
                 (estimate.startup_cost, estimate.total_cost)
             } else {
-                // Fallback to quick estimate if no cached estimate
                 log!("No cached estimate, using fallback costs");
                 (10.0, (*baserel).rows * 0.1 + 10.0)
             }
         } else {
-            // Default fallback costs
             log!("State not available, using default costs");
             (10.0, 100.0)
         };
@@ -234,7 +168,7 @@ extern "C-unwind" fn get_foreign_paths(
             ptr::null_mut(),
             (*baserel).rows,
             #[cfg(feature = "pg18")]
-            0, // disabled_nodes
+            0,
             startup_cost,
             total_cost,
             ptr::null_mut(),
@@ -245,6 +179,17 @@ extern "C-unwind" fn get_foreign_paths(
             ptr::null_mut(),
         );
         pgrx::pg_sys::add_path(baserel, path as *mut pgrx::pg_sys::Path);
+
+        if !state_ptr.is_null() {
+            let state = &*state_ptr;
+            let supports_param = matches!(
+                state.table_type,
+                RedisTableType::Hash(_) | RedisTableType::Set(_) | RedisTableType::ZSet(_)
+            );
+            if supports_param && !state.is_multi_key {
+                add_parameterized_paths(_root, baserel, state);
+            }
+        }
     }
 }
 
@@ -260,18 +205,69 @@ unsafe extern "C-unwind" fn get_foreign_plan(
 ) -> *mut pgrx::pg_sys::ForeignScan {
     log!("---> get_foreign_plan");
 
-    // Join relation: scanrelid=0, build join plan
     if (*baserel).reloptkind == pg_sys::RelOptKind::RELOPT_JOINREL {
         return plan_foreign_join(root, baserel, best_path, tlist, scan_clauses, outer_plan);
     }
 
-    // Base relation: normal scan plan
     let state = state_from_ptr((*baserel).fdw_private);
+
+    let is_parameterized = !(*best_path).path.param_info.is_null();
+    let mut fdw_exprs: *mut pg_sys::List = ptr::null_mut();
+    let mut param_col_idx: usize = 0;
+
+    if is_parameterized {
+        let my_relids = (*baserel).relids;
+        let clause_list = pg_sys::extract_actual_clauses(scan_clauses, false);
+        let clause_len = pg_sys::list_length(clause_list);
+        for i in 0..clause_len {
+            let clause_node = pg_sys::list_nth(clause_list, i) as *mut pg_sys::Node;
+            if clause_node.is_null() || (*clause_node).type_ != pg_sys::NodeTag::T_OpExpr {
+                continue;
+            }
+            let op_expr = &*(clause_node as *mut pg_sys::OpExpr);
+            if pg_sys::list_length(op_expr.args) != 2 {
+                continue;
+            }
+            let left_arg = pg_sys::list_nth(op_expr.args, 0) as *mut pg_sys::Node;
+            let right_arg = pg_sys::list_nth(op_expr.args, 1) as *mut pg_sys::Node;
+            if left_arg.is_null() || right_arg.is_null() {
+                continue;
+            }
+            if (*left_arg).type_ != pg_sys::NodeTag::T_Var
+                || (*right_arg).type_ != pg_sys::NodeTag::T_Var
+            {
+                continue;
+            }
+            let left_var = &*(left_arg as *mut pg_sys::Var);
+            let right_var = &*(right_arg as *mut pg_sys::Var);
+
+            let left_is_mine = pg_sys::bms_is_member(left_var.varno as i32, my_relids);
+            let right_is_mine = pg_sys::bms_is_member(right_var.varno as i32, my_relids);
+
+            if left_is_mine && !right_is_mine {
+                param_col_idx = (left_var.varattno - 1) as usize;
+                fdw_exprs = pg_sys::lappend(fdw_exprs, right_arg as *mut std::ffi::c_void);
+                break;
+            } else if right_is_mine && !left_is_mine {
+                param_col_idx = (right_var.varattno - 1) as usize;
+                fdw_exprs = pg_sys::lappend(fdw_exprs, left_arg as *mut std::ffi::c_void);
+                break;
+            }
+        }
+
+        if !fdw_exprs.is_null() {
+            state.is_parameterized = true;
+            state.param_column = param_col_idx;
+            log!(
+                "Parameterized scan: column {} will receive join key from outer",
+                param_col_idx
+            );
+        }
+    }
 
     PgMemoryContexts::For(state.tmp_ctx).switch_to(|_| {
         let relation = pg_sys::relation_open(foreigntableid, pg_sys::AccessShareLock as _);
 
-        // Analyze WHERE clauses for pushdown opportunities
         let mut pushdown_analysis = WhereClausePushdown::analyze_scan_clauses(
             scan_clauses,
             &state.table_type,
@@ -299,138 +295,19 @@ unsafe extern "C-unwind" fn get_foreign_plan(
             log!("No pushdown optimizations possible");
         }
 
-        // Store the analysis in the state
         state.set_pushdown_analysis(pushdown_analysis);
 
         pg_sys::relation_close(relation, pg_sys::AccessShareLock as _);
     });
 
-    // Serialize state pointer to a proper PG List for safe plan copying
     let fdw_private = serialize_ptr_to_list((*baserel).fdw_private);
     pgrx::pg_sys::make_foreignscan(
         tlist,
         pg_sys::extract_actual_clauses(scan_clauses, false),
         (*baserel).relid,
-        ptr::null_mut(),
+        fdw_exprs,
         fdw_private as _,
         ptr::null_mut(),
-        ptr::null_mut(),
-        outer_plan,
-    )
-}
-
-unsafe fn plan_foreign_join(
-    _root: *mut pgrx::pg_sys::PlannerInfo,
-    joinrel: *mut pgrx::pg_sys::RelOptInfo,
-    best_path: *mut pgrx::pg_sys::ForeignPath,
-    tlist: *mut pgrx::pg_sys::List,
-    scan_clauses: *mut pgrx::pg_sys::List,
-    outer_plan: *mut pgrx::pg_sys::Plan,
-) -> *mut pgrx::pg_sys::ForeignScan {
-    log!("---> plan_foreign_join");
-
-    // Extract outer/inner state from the ForeignPath's fdw_private
-    let path_private = (*best_path).fdw_private;
-    let outer_state_ptr = deserialize_nth_ptr_from_list(path_private, 0) as *mut RedisFdwState;
-    let inner_state_ptr = deserialize_nth_ptr_from_list(path_private, 1) as *mut RedisFdwState;
-
-    if outer_state_ptr.is_null() || inner_state_ptr.is_null() {
-        pgrx::error!("Join plan: missing outer/inner state in fdw_private");
-    }
-
-    let outer_state = &*outer_state_ptr;
-    let inner_state = &*inner_state_ptr;
-
-    // Read the join type from the third list element
-    let jointype_val = deserialize_nth_ptr_from_list(path_private, 2) as i64;
-    let join_type = if jointype_val == pgrx::pg_sys::JoinType::JOIN_LEFT as i64 {
-        RedisJoinType::Left
-    } else {
-        RedisJoinType::Inner
-    };
-
-    // Read join columns from 4th and 5th list elements
-    let join_col_outer = deserialize_nth_ptr_from_list(path_private, 3) as usize;
-    let join_col_inner = deserialize_nth_ptr_from_list(path_private, 4) as usize;
-
-    // Read relation IDs from 6th and 7th list elements
-    let outer_relid = deserialize_nth_ptr_from_list(path_private, 5) as pg_sys::Index;
-    let inner_relid = deserialize_nth_ptr_from_list(path_private, 6) as pg_sys::Index;
-
-    // Build the RedisJoinState with table info from both sides
-    let join_state = RedisJoinState::new(
-        outer_state.table_type.clone(),
-        inner_state.table_type.clone(),
-        outer_state.table_key_prefix.clone(),
-        inner_state.table_key_prefix.clone(),
-        join_type,
-        join_col_outer,
-        join_col_inner,
-    );
-
-    // Create a new RedisFdwState for the join scan
-    let ctx_name = "Wrappers_join_scan";
-    let ctx = create_wrappers_memctx(ctx_name);
-    let mut state = RedisFdwState::new(ctx);
-
-    // Copy connection info from outer (same server guaranteed by get_foreign_join_paths)
-    state.host_port = outer_state.host_port.clone();
-    state.database = outer_state.database;
-    state.opts = outer_state.opts.clone();
-    state.is_join_scan = true;
-    state.join_state = Some(join_state);
-
-    let state_ptr = PgMemoryContexts::For(ctx).leak_and_drop_on_delete(state);
-    (*joinrel).fdw_private = state_ptr as *mut std::os::raw::c_void;
-
-    let outer_ncols = crate::join::foreign_join::expected_columns_for_type(&outer_state.table_type);
-    let inner_ncols = crate::join::foreign_join::expected_columns_for_type(&inner_state.table_type);
-
-    // Build fdw_scan_tlist: declare our scan produces [outer_col1..N, inner_col1..M]
-    // This matches the combined row layout from execute_foreign_join.
-    // Since we skip pushdown when base restrictions exist (checked in
-    // get_foreign_join_paths), all quals here only reference join columns
-    // that are already in the tlist.
-    let mut fdw_scan_tlist: *mut pg_sys::List = ptr::null_mut();
-    let mut resno: i16 = 1;
-
-    for attno in 1..=(outer_ncols as i16) {
-        let var = pg_sys::makeVar(
-            outer_relid as _,
-            attno,
-            pg_sys::TEXTOID,
-            -1,
-            pg_sys::DEFAULT_COLLATION_OID,
-            0,
-        );
-        let tle = pg_sys::makeTargetEntry(var as *mut pg_sys::Expr, resno, ptr::null_mut(), false);
-        fdw_scan_tlist = pg_sys::lappend(fdw_scan_tlist, tle as *mut std::ffi::c_void);
-        resno += 1;
-    }
-    for attno in 1..=(inner_ncols as i16) {
-        let var = pg_sys::makeVar(
-            inner_relid as _,
-            attno,
-            pg_sys::TEXTOID,
-            -1,
-            pg_sys::DEFAULT_COLLATION_OID,
-            0,
-        );
-        let tle = pg_sys::makeTargetEntry(var as *mut pg_sys::Expr, resno, ptr::null_mut(), false);
-        fdw_scan_tlist = pg_sys::lappend(fdw_scan_tlist, tle as *mut std::ffi::c_void);
-        resno += 1;
-    }
-
-    let fdw_private = serialize_ptr_to_list(state_ptr as *mut std::os::raw::c_void);
-    let local_quals = pg_sys::extract_actual_clauses(scan_clauses, false);
-
-    pgrx::pg_sys::make_foreignscan(
-        tlist,
-        local_quals, // apply any joinrel-level quals locally after scan
-        0,           // scanrelid=0 for join
-        ptr::null_mut(),
-        fdw_private as _,
-        fdw_scan_tlist,
         ptr::null_mut(),
         outer_plan,
     )
@@ -447,13 +324,11 @@ extern "C-unwind" fn begin_foreign_scan(
         let plan: *mut pg_sys::ForeignScan = scan_state.ps.plan as *mut pg_sys::ForeignScan;
         let scanrelid = (*plan).scan.scanrelid;
 
-        // Join scan: scanrelid == 0 means this is a pushed-down join
         if scanrelid == 0 {
             begin_foreign_join_scan(node, plan);
             return;
         }
 
-        // Normal base relation scan
         let relation = (*node).ss.ss_currentRelation;
         let relid = (*relation).rd_id;
         let state_ptr = deserialize_ptr_from_list((*plan).fdw_private as _);
@@ -463,7 +338,6 @@ extern "C-unwind" fn begin_foreign_scan(
             log!("Foreign table options: {:?}", options);
             state.update_from_options(options);
 
-            // Acquire connection from pool (fast path: read-lock on existing pool)
             if state.redis_connection.is_none() {
                 if let Err(e) = state.init_redis_connection_from_options() {
                     pgrx::error!("Failed to connect to Redis: {}", e);
@@ -473,7 +347,6 @@ extern "C-unwind" fn begin_foreign_scan(
             state.set_table_type();
         });
 
-        // Detect TTL column
         let relation = (*node).ss.ss_currentRelation;
         let tupdesc = (*relation).rd_att;
         state.ttl_column_index = detect_ttl_column(tupdesc);
@@ -485,7 +358,12 @@ extern "C-unwind" fn begin_foreign_scan(
         }
         state.column_names = col_names;
 
-        // Configure table types that need column info
+        validate_column_count(
+            &state.table_type,
+            state.column_names.len(),
+            state.is_multi_key,
+        );
+
         if let RedisTableType::List(ref mut list) = state.table_type {
             list.include_index = state.column_names.len() >= 2;
         }
@@ -493,38 +371,25 @@ extern "C-unwind" fn begin_foreign_scan(
             stream.column_names = state.column_names.clone();
         }
 
-        // Pre-fetch TTL for single-key mode to avoid per-row Redis calls during iteration
         if state.ttl_column_index.is_some() && !state.is_multi_key {
             let key = state.table_key_prefix.clone();
             state.read_ttl(&key);
         }
 
+        if state.is_parameterized && !(*plan).fdw_exprs.is_null() {
+            let expr_list = (*plan).fdw_exprs;
+            if pg_sys::list_length(expr_list) > 0 {
+                let first_expr = pg_sys::list_nth(expr_list, 0) as *mut pg_sys::Expr;
+                let plan_state = &mut (*node).ss.ps as *mut pg_sys::PlanState;
+                state.param_expr_state = pg_sys::ExecInitExpr(first_expr, plan_state);
+                state.param_plan_state = plan_state;
+                log!("Parameterized scan: ExprState initialized for join key evaluation");
+            }
+        }
+
         log!("Connected to Redis");
         (*node).fdw_state = state_ptr;
     }
-}
-
-unsafe fn begin_foreign_join_scan(
-    node: *mut pgrx::pg_sys::ForeignScanState,
-    plan: *mut pg_sys::ForeignScan,
-) {
-    log!("---> begin_foreign_join_scan");
-    let state_ptr = deserialize_ptr_from_list((*plan).fdw_private as _);
-    let state = state_from_ptr(state_ptr);
-
-    // Connect to Redis for the join execution
-    if state.redis_connection.is_none() {
-        if let Err(e) = state.init_redis_connection_from_options() {
-            pgrx::error!("Failed to connect to Redis for join scan: {}", e);
-        }
-    }
-
-    // Transfer connection to the join_state so execute_foreign_join can use it
-    if let Some(ref mut join_state) = state.join_state {
-        join_state.connection = state.redis_connection.take();
-    }
-
-    (*node).fdw_state = state_ptr;
 }
 
 #[pg_guard]
@@ -539,7 +404,7 @@ unsafe extern "C-unwind" fn iterate_foreign_scan(
 
     exec_clear_tuple(slot);
 
-    // Join pushdown mode: execute join on first call, then iterate results
+    // Join pushdown mode
     if state.is_join_scan {
         if let Some(ref mut join_state) = state.join_state {
             if !state.join_executed {
@@ -567,7 +432,47 @@ unsafe extern "C-unwind" fn iterate_foreign_scan(
         return slot;
     }
 
-    // Streaming iteration: if current batch is exhausted, fetch more
+    // Parameterized scan: point-lookup
+    if state.is_parameterized && !state.param_expr_state.is_null() {
+        if state.row_count > 0 {
+            return slot;
+        }
+
+        let econtext = (*node).ss.ps.ps_ExprContext;
+        let mut is_null: bool = false;
+        let datum = pg_sys::ExecEvalExpr(state.param_expr_state, econtext, &mut is_null);
+        if is_null {
+            return slot;
+        }
+
+        let param_value = datum_to_text_string(
+            datum,
+            state.param_column,
+            (*(*node).ss.ss_currentRelation).rd_att,
+        );
+
+        if state.parameterized_lookup(&param_value) {
+            let natts_param = (*tupdesc).natts as usize;
+            if let Some(row_data) = state.get_row(0) {
+                let mut data_idx = 0;
+                for col_idx in 0..natts_param {
+                    if state.ttl_column_index == Some(col_idx) {
+                        let val = state.cached_ttl.unwrap_or(-2);
+                        write_datum_to_slot(slot, tupdesc, col_idx, &val.to_string());
+                    } else if data_idx < row_data.len() {
+                        write_datum_to_slot(slot, tupdesc, col_idx, row_data[data_idx].as_ref());
+                        data_idx += 1;
+                    }
+                }
+            }
+            state.row_count = 1;
+            pg_sys::ExecStoreVirtualTuple(slot);
+            return slot;
+        }
+        return slot;
+    }
+
+    // Streaming iteration
     if state.is_read_end() {
         if state.scan_complete {
             return slot;
@@ -660,8 +565,6 @@ extern "C-unwind" fn end_foreign_scan(node: *mut pgrx::pg_sys::ForeignScanState)
             return;
         }
         let state = &mut *fdw_state;
-        // Destroy the memory context — this triggers the registered Drop callback
-        // which properly frees the RedisFdwState and all its owned Rust resources
         let ctx = state.tmp_ctx;
         if !ctx.is_null() {
             delete_wrappers_memctx(ctx);
@@ -680,7 +583,6 @@ extern "C-unwind" fn re_scan_foreign_scan(node: *mut pgrx::pg_sys::ForeignScanSt
         let state = &mut *fdw_state;
 
         if state.is_join_scan {
-            // Reset iterator to re-read materialized results without re-fetching from Redis
             if let Some(ref mut join_state) = state.join_state {
                 join_state.current_row = 0;
             }
@@ -733,14 +635,13 @@ unsafe extern "C-unwind" fn add_foreign_update_targets(
 
     let var = pg_sys::makeVar(
         rtindex as _,
-        1, //attr.attnum,
+        1,
         attr.atttypid,
         attr.atttypmod,
-        pg_sys::InvalidOid, //attr.attlen,
+        pg_sys::InvalidOid,
         0,
     );
 
-    // register it as a row-identity column needed by this target rel
     pg_sys::add_row_identity_var(root, var, rtindex, REDISMODY.as_ptr() as _);
 }
 
@@ -763,14 +664,12 @@ unsafe extern "C-unwind" fn plan_foreign_modify(
         log!("Foreign table options for modify: {:?}", opts);
         state.update_from_options(opts);
 
-        // Initialize Redis connection and handle potential errors
         if let Err(e) = state.init_redis_connection_from_options() {
             pgrx::error!("Failed to connect to Redis: {}", e);
         }
 
         state.set_table_type();
     });
-    // Allocate state in PG memory context — Drop fires on context destruction (longjmp-safe)
     let state_ptr = PgMemoryContexts::For(ctx).leak_and_drop_on_delete(state);
     serialize_ptr_to_list(state_ptr as *mut std::os::raw::c_void)
 }
@@ -791,7 +690,6 @@ unsafe extern "C-unwind" fn begin_foreign_modify(
         pg_sys::ExecFindJunkAttributeInTlist((*subplan).targetlist, REDISMODY.as_ptr() as _);
     log!("Key attribute number: {}", state.key_attno);
 
-    // Detect TTL column in the target relation
     let relation = (*rinfo).ri_RelationDesc;
     let tupdesc = (*relation).rd_att;
     state.ttl_column_index = detect_ttl_column(tupdesc);
@@ -803,7 +701,12 @@ unsafe extern "C-unwind" fn begin_foreign_modify(
     }
     state.column_names = col_names;
 
-    // Configure table types that need column info
+    validate_column_count(
+        &state.table_type,
+        state.column_names.len(),
+        state.is_multi_key,
+    );
+
     if let RedisTableType::List(ref mut list) = state.table_type {
         list.include_index = state.column_names.len() >= 2;
     }
@@ -836,7 +739,6 @@ unsafe extern "C-unwind" fn exec_foreign_insert(
         .map(|cell| cell_to_string(cell.as_ref()))
         .collect();
 
-    // Extract and strip TTL column value
     let (data, row_ttl) = if let Some(ttl_idx) = state.ttl_column_index {
         let ttl_val = all_data.get(ttl_idx).and_then(|s| {
             if s == "NULL" {
@@ -855,7 +757,6 @@ unsafe extern "C-unwind" fn exec_foreign_insert(
     };
 
     if state.is_multi_key {
-        // Multi-key mode: first column is the Redis key, remaining columns are data
         if data.is_empty() {
             error!("Multi-key INSERT requires at least a key column");
         }
@@ -874,7 +775,6 @@ unsafe extern "C-unwind" fn exec_foreign_insert(
         }
         state.apply_ttl(&key, row_ttl);
     } else {
-        // Transform data for specific table types
         let data = transform_insert_data(&state.table_type, &state.column_names, data);
         if let Err(e) = state.insert_data(&data) {
             error!("Failed to insert data: {:?}", e);
@@ -897,7 +797,6 @@ unsafe extern "C-unwind" fn exec_foreign_update(
     log!("---> exec_foreign_update");
     let state = state_from_ptr((*rinfo).ri_FdwState);
 
-    // Extract old key from plan_slot (junk attribute set by add_foreign_update_targets)
     let old_key = match extract_delete_key(state, plan_slot) {
         Ok(key) => key,
         Err(err_msg) => {
@@ -905,7 +804,6 @@ unsafe extern "C-unwind" fn exec_foreign_update(
         }
     };
 
-    // Extract new row from the slot
     let new_row: Row = tuple_table_slot_to_row(slot);
     let all_new_data: Vec<String> = new_row
         .cells
@@ -913,7 +811,6 @@ unsafe extern "C-unwind" fn exec_foreign_update(
         .map(|cell| cell_to_string(cell.as_ref()))
         .collect();
 
-    // Extract and strip TTL column value
     let (new_data, row_ttl) = if let Some(ttl_idx) = state.ttl_column_index {
         let ttl_val = all_new_data.get(ttl_idx).and_then(|s| {
             if s == "NULL" {
@@ -972,10 +869,8 @@ unsafe extern "C-unwind" fn exec_foreign_delete(
 ) -> *mut pgrx::pg_sys::TupleTableSlot {
     log!("---> exec_foreign_delete");
 
-    // Extract state and validate it's not null
     let state = state_from_ptr((*rinfo).ri_FdwState);
 
-    // Extract the key attribute for deletion
     match extract_delete_key(state, plan_slot) {
         Ok(key) => {
             log!("Attempting to delete key: '{}'", key);
@@ -994,7 +889,6 @@ unsafe extern "C-unwind" fn exec_foreign_delete(
         }
     }
 
-    // Mark slot as having an invalid table OID since this is a delete operation
     (*slot).tts_tableOid = pgrx::pg_sys::InvalidOid;
 
     slot
@@ -1013,7 +907,6 @@ unsafe extern "C-unwind" fn end_foreign_modify(
         }
 
         let state = &*fdw_state;
-        // Destroy the memory context — this triggers the registered Drop callback
         let ctx = state.tmp_ctx;
         if !ctx.is_null() {
             delete_wrappers_memctx(ctx);
@@ -1054,7 +947,6 @@ unsafe extern "C-unwind" fn begin_foreign_insert(
     }
     state.column_names = col_names;
 
-    // Configure table types that need column info
     if let RedisTableType::List(ref mut list) = state.table_type {
         list.include_index = state.column_names.len() >= 2;
     }
@@ -1089,165 +981,16 @@ extern "C-unwind" fn is_foreign_rel_updatable(
     rel: pgrx::pg_sys::Relation,
 ) -> ::std::os::raw::c_int {
     log!("---> is_foreign_rel_updatable");
-    // CmdType: CMD_UPDATE=2, CMD_INSERT=3, CMD_DELETE=4
-    // Return bitmask: (1 << CMD_INSERT) | (1 << CMD_UPDATE) | (1 << CMD_DELETE)
-    // = 8 | 4 | 16 = 28 for updatable types
-    // = 8 | 16 = 24 for stream (no UPDATE)
     unsafe {
         let relid = (*rel).rd_id;
         let options = get_foreign_table_options(relid);
         let table_type = options.get("table_type").map(|s| s.as_str()).unwrap_or("");
 
         match table_type.to_lowercase().as_str() {
-            "stream" => (1 << 3) | (1 << 4),     // INSERT | DELETE = 24
-            _ => (1 << 2) | (1 << 3) | (1 << 4), // UPDATE | INSERT | DELETE = 28
+            "stream" => (1 << 3) | (1 << 4),
+            _ => (1 << 2) | (1 << 3) | (1 << 4),
         }
     }
-}
-
-unsafe fn extract_delete_key(
-    state: &RedisFdwState,
-    plan_slot: *mut pgrx::pg_sys::TupleTableSlot,
-) -> Result<String, &'static str> {
-    // Validate key attribute number
-    if state.key_attno <= 0 {
-        return Err("Invalid key attribute number");
-    }
-
-    // Extract the junk attribute (row identifier)
-    let mut is_null = false;
-    let datum = exec_get_junk_attribute(plan_slot, state.key_attno, &mut is_null);
-
-    // Convert datum to string safely
-    match String::from_datum(datum, is_null) {
-        Some(key_string) => {
-            if key_string.is_empty() {
-                Err("Delete key is empty")
-            } else {
-                Ok(key_string)
-            }
-        }
-        None => Err("Failed to convert datum to string"),
-    }
-}
-
-#[pg_guard]
-unsafe extern "C-unwind" fn explain_foreign_scan(
-    node: *mut pg_sys::ForeignScanState,
-    es: *mut pg_sys::ExplainState,
-) {
-    log!("---> explain_foreign_scan");
-    let fdw_state = (*node).fdw_state as *mut RedisFdwState;
-    if fdw_state.is_null() {
-        return;
-    }
-    let state = &*fdw_state;
-
-    if state.is_join_scan {
-        let label_join = c"Redis Join";
-        let join_desc = if let Some(ref js) = state.join_state {
-            format!(
-                "{}({}) x {}({})",
-                js.outer_table_type.redis_type_name(),
-                js.outer_key_prefix,
-                js.inner_table_type.redis_type_name(),
-                js.inner_key_prefix
-            )
-        } else {
-            "FDW-to-FDW pushdown".to_string()
-        };
-        let join_cstr = CString::new(join_desc).unwrap_or_default();
-        pg_sys::ExplainPropertyText(label_join.as_ptr(), join_cstr.as_ptr(), es);
-
-        let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
-        let label_server = c"Redis Server";
-        pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
-        return;
-    }
-
-    let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
-    let key_cstr = CString::new(state.table_key_prefix.as_str()).unwrap_or_default();
-    let type_name = state.table_type.redis_type_name();
-    let type_cstr = CString::new(type_name).unwrap_or_default();
-    let multi_key_cstr =
-        CString::new(if state.is_multi_key { "true" } else { "false" }).unwrap_or_default();
-
-    let label_server = c"Redis Server";
-    let label_key = c"Redis Key";
-    let label_type = c"Table Type";
-    let label_multi = c"Multi-Key Mode";
-    let label_pushdown = c"Pushdown";
-    let label_batch = c"Batch Size";
-
-    pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
-    pg_sys::ExplainPropertyText(label_key.as_ptr(), key_cstr.as_ptr(), es);
-    pg_sys::ExplainPropertyText(label_type.as_ptr(), type_cstr.as_ptr(), es);
-    pg_sys::ExplainPropertyText(label_multi.as_ptr(), multi_key_cstr.as_ptr(), es);
-
-    let pushdown_desc = if let Some(ref analysis) = state.pushdown_analysis {
-        if analysis.has_optimizations() {
-            analysis
-                .pushable_conditions
-                .iter()
-                .map(|c| format!("{} {} '{}'", c.column_name, c.operator, c.value))
-                .collect::<Vec<_>>()
-                .join(", ")
-        } else {
-            "none".to_string()
-        }
-    } else {
-        "none".to_string()
-    };
-    let pushdown_cstr = CString::new(pushdown_desc).unwrap_or_default();
-    pg_sys::ExplainPropertyText(label_pushdown.as_ptr(), pushdown_cstr.as_ptr(), es);
-
-    let label_batch_unit = c"rows";
-    pg_sys::ExplainPropertyInteger(
-        label_batch.as_ptr(),
-        label_batch_unit.as_ptr(),
-        state.batch_size as i64,
-        es,
-    );
-
-    if (*es).analyze {
-        let label_rows = c"Rows Fetched";
-        let label_rows_unit = c"rows";
-        pg_sys::ExplainPropertyInteger(
-            label_rows.as_ptr(),
-            label_rows_unit.as_ptr(),
-            state.row_count as i64,
-            es,
-        );
-    }
-}
-
-#[pg_guard]
-unsafe extern "C-unwind" fn explain_foreign_modify(
-    _mtstate: *mut pg_sys::ModifyTableState,
-    rinfo: *mut pg_sys::ResultRelInfo,
-    _fdw_private: *mut pg_sys::List,
-    _subplan_index: ::core::ffi::c_int,
-    es: *mut pg_sys::ExplainState,
-) {
-    log!("---> explain_foreign_modify");
-    let fdw_state = (*rinfo).ri_FdwState as *mut RedisFdwState;
-    if fdw_state.is_null() {
-        return;
-    }
-    let state = &*fdw_state;
-
-    let server_cstr = CString::new(state.host_port.as_str()).unwrap_or_default();
-    let key_cstr = CString::new(state.table_key_prefix.as_str()).unwrap_or_default();
-    let type_name = state.table_type.redis_type_name();
-    let type_cstr = CString::new(type_name).unwrap_or_default();
-
-    let label_server = c"Redis Server";
-    let label_key = c"Redis Key";
-    let label_type = c"Table Type";
-
-    pg_sys::ExplainPropertyText(label_server.as_ptr(), server_cstr.as_ptr(), es);
-    pg_sys::ExplainPropertyText(label_key.as_ptr(), key_cstr.as_ptr(), es);
-    pg_sys::ExplainPropertyText(label_type.as_ptr(), type_cstr.as_ptr(), es);
 }
 
 #[pg_guard]
@@ -1315,808 +1058,4 @@ unsafe extern "C-unwind" fn exec_foreign_batch_insert(
     }
 
     slots
-}
-
-#[pg_guard]
-unsafe extern "C-unwind" fn exec_foreign_truncate(
-    rels: *mut pg_sys::List,
-    _behavior: pg_sys::DropBehavior::Type,
-    _restart_seqs: bool,
-) {
-    log!("---> exec_foreign_truncate");
-    use crate::core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory};
-    use crate::core::state_manager::is_multi_key_pattern;
-
-    if rels.is_null() {
-        return;
-    }
-
-    pgrx::memcx::current_context(|mcx| {
-        let rel_list = pgrx::list::List::<*mut std::ffi::c_void>::downcast_ptr_in_memcx(rels, mcx)
-            .expect("Failed to downcast rels list");
-
-        for rel_ptr in rel_list.iter() {
-            let relation = *rel_ptr as pg_sys::Relation;
-            if relation.is_null() {
-                continue;
-            }
-            let relid = (*relation).rd_id;
-            let options = get_foreign_table_options(relid);
-
-            let config = match RedisConnectionConfig::from_options(&options) {
-                Ok(c) => c,
-                Err(e) => {
-                    error!("Failed to create Redis config for truncate: {}", e);
-                }
-            };
-
-            let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
-                Ok(c) => c,
-                Err(e) => {
-                    error!("Failed to connect to Redis for truncate: {}", e);
-                }
-            };
-
-            let conn_like = conn.as_connection_like_mut();
-            let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
-
-            if is_multi_key_pattern(&key_prefix) {
-                let mut cursor: u64 = 0;
-                loop {
-                    pgrx::check_for_interrupts!();
-                    let (new_cursor, keys): (u64, Vec<String>) = match redis::cmd("SCAN")
-                        .arg(cursor)
-                        .arg("MATCH")
-                        .arg(&key_prefix)
-                        .arg("COUNT")
-                        .arg(1000u32)
-                        .query(conn_like)
-                    {
-                        Ok(r) => r,
-                        Err(e) => {
-                            error!("Redis SCAN error during truncate: {}", e);
-                        }
-                    };
-
-                    if !keys.is_empty() {
-                        let mut pipe = redis::pipe();
-                        for key in &keys {
-                            pipe.cmd("UNLINK").arg(key);
-                        }
-                        if let Err(e) = pipe.query::<Vec<redis::Value>>(conn_like) {
-                            error!("Redis UNLINK pipeline failed during truncate: {}", e);
-                        }
-                    }
-
-                    cursor = new_cursor;
-                    if cursor == 0 {
-                        break;
-                    }
-                }
-            } else if let Err(e) = redis::cmd("UNLINK")
-                .arg(&key_prefix)
-                .query::<i64>(conn_like)
-            {
-                error!("Redis UNLINK failed for key '{}': {}", key_prefix, e);
-            }
-        }
-    });
-}
-
-#[pg_guard]
-unsafe extern "C-unwind" fn import_foreign_schema(
-    stmt: *mut pg_sys::ImportForeignSchemaStmt,
-    server_oid: pg_sys::Oid,
-) -> *mut pg_sys::List {
-    log!("---> import_foreign_schema");
-    use crate::core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory};
-    use std::collections::HashMap as StdHashMap;
-
-    let server = pg_sys::GetForeignServer(server_oid);
-    let mut options: StdHashMap<String, String> = StdHashMap::new();
-
-    pgrx::memcx::current_context(|mcx| {
-        if !(*server).options.is_null() {
-            let opts_list = pg_list_to_rust_list::<*mut std::ffi::c_void>((*server).options, mcx);
-            for option in opts_list.iter() {
-                let def_elem = (*option).cast::<pg_sys::DefElem>();
-                if !def_elem.is_null() {
-                    options.insert(
-                        string_from_cstr((*def_elem).defname),
-                        string_from_cstr(pg_sys::defGetString(def_elem)),
-                    );
-                }
-            }
-        }
-    });
-
-    let config = match RedisConnectionConfig::from_options(&options) {
-        Ok(c) => c,
-        Err(e) => {
-            error!("Failed to create Redis config for import: {}", e);
-        }
-    };
-
-    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
-        Ok(c) => c,
-        Err(e) => {
-            error!("Failed to connect to Redis for import: {}", e);
-        }
-    };
-
-    let conn_like = conn.as_connection_like_mut();
-
-    // SCAN to sample keys
-    let mut all_keys: Vec<String> = Vec::new();
-    let mut cursor: u64 = 0;
-    let max_keys: usize = 10_000;
-    loop {
-        pgrx::check_for_interrupts!();
-        let (new_cursor, keys): (u64, Vec<String>) = match redis::cmd("SCAN")
-            .arg(cursor)
-            .arg("COUNT")
-            .arg(1000u32)
-            .query(conn_like)
-        {
-            Ok(r) => r,
-            Err(e) => {
-                error!("Redis SCAN error during import: {}", e);
-            }
-        };
-
-        all_keys.extend(keys);
-        cursor = new_cursor;
-        if cursor == 0 || all_keys.len() >= max_keys {
-            break;
-        }
-    }
-
-    if all_keys.len() > max_keys {
-        all_keys.truncate(max_keys);
-    }
-
-    if all_keys.is_empty() {
-        return ptr::null_mut();
-    }
-
-    // TYPE each key using pipeline
-    let mut pipe = redis::pipe();
-    for key in &all_keys {
-        pipe.cmd("TYPE").arg(key);
-    }
-    let types: Vec<String> = match pipe.query(conn_like) {
-        Ok(t) => t,
-        Err(e) => {
-            error!("Redis TYPE pipeline error during import: {}", e);
-        }
-    };
-
-    // Group keys by prefix and type
-    let mut groups: StdHashMap<String, String> = StdHashMap::new();
-    for (key, redis_type) in all_keys.iter().zip(types.iter()) {
-        if redis_type == "none" {
-            continue;
-        }
-        let prefix = derive_key_prefix(key);
-        groups.entry(prefix).or_insert_with(|| redis_type.clone());
-    }
-
-    // Build LIMIT TO / EXCEPT filter
-    let list_type = (*stmt).list_type;
-    let mut filter_names: Vec<String> = Vec::new();
-    if !(*stmt).table_list.is_null() {
-        pgrx::memcx::current_context(|mcx| {
-            let table_list = pgrx::list::List::<*mut std::ffi::c_void>::downcast_ptr_in_memcx(
-                (*stmt).table_list,
-                mcx,
-            )
-            .expect("Failed to downcast table_list");
-            for item in table_list.iter() {
-                let rv = *item as *mut pg_sys::RangeVar;
-                if !rv.is_null() && !(*rv).relname.is_null() {
-                    filter_names.push(string_from_cstr((*rv).relname));
-                }
-            }
-        });
-    }
-
-    // Generate DDL statements
-    let server_name = string_from_cstr((*stmt).server_name);
-    let mut result_list: *mut pg_sys::List = ptr::null_mut();
-
-    for (prefix, redis_type) in &groups {
-        let table_name = sanitize_table_name(prefix);
-
-        match list_type {
-            pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_LIMIT_TO
-                if !filter_names.contains(&table_name) =>
-            {
-                continue;
-            }
-            pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_EXCEPT
-                if filter_names.contains(&table_name) =>
-            {
-                continue;
-            }
-            _ => {}
-        }
-
-        let columns = columns_for_type(redis_type);
-        let key_pattern = format!("{}*", prefix);
-        let database_str = config.database.to_string();
-
-        let quoted_table = table_name.replace('"', "\"\"");
-        let quoted_server = server_name.replace('"', "\"\"");
-        let escaped_prefix = key_pattern.replace('\'', "''");
-
-        let ddl = format!(
-            "CREATE FOREIGN TABLE \"{}\" ({}) SERVER \"{}\" OPTIONS (database '{}', table_type '{}', table_key_prefix '{}')",
-            quoted_table, columns, quoted_server, database_str, redis_type, escaped_prefix
-        );
-
-        let ddl_cstr = match CString::new(ddl) {
-            Ok(c) => c,
-            Err(_) => {
-                error!("import_foreign_schema: table name contains null byte");
-            }
-        };
-        let pg_str = pg_sys::pstrdup(ddl_cstr.as_ptr());
-        result_list = pg_sys::lappend(result_list, pg_str as *mut std::ffi::c_void);
-    }
-
-    result_list
-}
-
-fn derive_key_prefix(key: &str) -> String {
-    if let Some(pos) = key.rfind(':') {
-        key[..=pos].to_string()
-    } else {
-        format!("{}_", key)
-    }
-}
-
-fn sanitize_table_name(prefix: &str) -> String {
-    let mut name: String = prefix
-        .trim_end_matches(':')
-        .trim_end_matches('_')
-        .replace([':', '-', '.'], "_")
-        .chars()
-        .filter(|c| c.is_alphanumeric() || *c == '_')
-        .collect();
-
-    if name.starts_with(|c: char| c.is_ascii_digit()) {
-        name = format!("t_{}", name);
-    }
-
-    if name.is_empty() {
-        name = "redis_table".to_string();
-    }
-
-    if name.len() > 63 {
-        name.truncate(63);
-    }
-
-    name
-}
-
-fn columns_for_type(redis_type: &str) -> &'static str {
-    match redis_type {
-        "hash" => "key text, field text, value text",
-        "list" => "key text, element text",
-        "set" => "key text, member text",
-        "zset" => "key text, member text, score text",
-        "string" => "key text, value text",
-        "stream" => "stream_id text, field text, value text",
-        _ => "value text",
-    }
-}
-
-#[pg_guard]
-unsafe extern "C-unwind" fn analyze_foreign_table(
-    relation: pg_sys::Relation,
-    func: *mut pg_sys::AcquireSampleRowsFunc,
-    totalpages: *mut pg_sys::BlockNumber,
-) -> bool {
-    log!("---> analyze_foreign_table");
-    use crate::core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory};
-    use crate::core::state_manager::is_multi_key_pattern;
-
-    let relid = (*relation).rd_id;
-    let options = get_foreign_table_options(relid);
-
-    let config = match RedisConnectionConfig::from_options(&options) {
-        Ok(c) => c,
-        Err(e) => {
-            log!("analyze_foreign_table: cannot create config: {}", e);
-            return false;
-        }
-    };
-
-    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
-        Ok(c) => c,
-        Err(e) => {
-            log!("analyze_foreign_table: cannot connect: {}", e);
-            return false;
-        }
-    };
-
-    let conn_like = conn.as_connection_like_mut();
-    let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
-    let table_type = options
-        .get("table_type")
-        .map(|s| s.as_str())
-        .unwrap_or("string");
-
-    let estimated_rows: u64 = if is_multi_key_pattern(&key_prefix) {
-        let mut cursor = 0u64;
-        let mut total_keys = 0u64;
-        let max_iterations = 100;
-        let mut iterations = 0;
-        loop {
-            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
-                .arg(cursor)
-                .arg("MATCH")
-                .arg(&key_prefix)
-                .arg("COUNT")
-                .arg(10000u32)
-                .query(conn_like)
-                .unwrap_or((0, Vec::new()));
-            total_keys += keys.len() as u64;
-            cursor = next_cursor;
-            iterations += 1;
-            if cursor == 0 || iterations >= max_iterations {
-                break;
-            }
-        }
-        total_keys
-    } else {
-        match table_type {
-            "hash" => redis::cmd("HLEN")
-                .arg(&key_prefix)
-                .query::<u64>(conn_like)
-                .unwrap_or(0),
-            "list" => redis::cmd("LLEN")
-                .arg(&key_prefix)
-                .query::<u64>(conn_like)
-                .unwrap_or(0),
-            "set" => redis::cmd("SCARD")
-                .arg(&key_prefix)
-                .query::<u64>(conn_like)
-                .unwrap_or(0),
-            "zset" => redis::cmd("ZCARD")
-                .arg(&key_prefix)
-                .query::<u64>(conn_like)
-                .unwrap_or(0),
-            "stream" => redis::cmd("XLEN")
-                .arg(&key_prefix)
-                .query::<u64>(conn_like)
-                .unwrap_or(0),
-            "string" => {
-                let exists: u64 = redis::cmd("EXISTS")
-                    .arg(&key_prefix)
-                    .query(conn_like)
-                    .unwrap_or(0);
-                exists
-            }
-            _ => 0,
-        }
-    };
-
-    let avg_row_width: u64 = 100;
-    let pages =
-        ((estimated_rows * avg_row_width) / pg_sys::BLCKSZ as u64).max(1) as pg_sys::BlockNumber;
-    *totalpages = pages;
-    *func = Some(acquire_sample_rows);
-    true
-}
-
-#[pg_guard]
-unsafe extern "C-unwind" fn acquire_sample_rows(
-    relation: pg_sys::Relation,
-    _elevel: ::core::ffi::c_int,
-    rows: *mut pg_sys::HeapTuple,
-    targrows: ::core::ffi::c_int,
-    totalrows: *mut f64,
-    totaldeadrows: *mut f64,
-) -> ::core::ffi::c_int {
-    log!("---> acquire_sample_rows (targrows={})", targrows);
-    use crate::core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory};
-    use crate::core::state_manager::is_multi_key_pattern;
-    use crate::query::limit::LimitOffsetInfo;
-
-    let relid = (*relation).rd_id;
-    let options = get_foreign_table_options(relid);
-    let tupdesc = (*relation).rd_att;
-    let natts = (*tupdesc).natts as usize;
-
-    let config = match RedisConnectionConfig::from_options(&options) {
-        Ok(c) => c,
-        Err(e) => {
-            log!("acquire_sample_rows: cannot create config: {}", e);
-            *totalrows = 0.0;
-            *totaldeadrows = 0.0;
-            return 0;
-        }
-    };
-
-    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
-        Ok(c) => c,
-        Err(e) => {
-            log!("acquire_sample_rows: cannot connect: {}", e);
-            *totalrows = 0.0;
-            *totaldeadrows = 0.0;
-            return 0;
-        }
-    };
-
-    let conn_like = conn.as_connection_like_mut();
-    let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
-    let table_type_str = options
-        .get("table_type")
-        .map(|s| s.as_str())
-        .unwrap_or("string");
-
-    let mut table_type = RedisTableType::from_str(table_type_str);
-    let is_multi_key = is_multi_key_pattern(&key_prefix);
-
-    let max_per_key = targrows as usize;
-    let sample_data: Vec<Vec<String>> = if is_multi_key {
-        let mut keys = Vec::new();
-        let mut cursor = 0u64;
-        loop {
-            let (next_cursor, batch): (u64, Vec<String>) = redis::cmd("SCAN")
-                .arg(cursor)
-                .arg("MATCH")
-                .arg(&key_prefix)
-                .arg("COUNT")
-                .arg(targrows as u32)
-                .query(conn_like)
-                .unwrap_or((0, Vec::new()));
-            keys.extend(batch);
-            cursor = next_cursor;
-            if cursor == 0 || keys.len() >= max_per_key {
-                break;
-            }
-        }
-        keys.truncate(max_per_key);
-        let mut result = Vec::new();
-
-        if table_type_str == "string" {
-            let mut pipe = redis::pipe();
-            for key in &keys {
-                pipe.cmd("GET").arg(key);
-            }
-            let vals: Vec<String> = pipe.query(conn_like).unwrap_or_default();
-            for (key, val) in keys.iter().zip(vals.into_iter()) {
-                result.push(vec![key.clone(), val]);
-            }
-        } else {
-            for key in &keys {
-                if result.len() >= max_per_key {
-                    break;
-                }
-                let remaining = max_per_key - result.len();
-                match table_type_str {
-                    "hash" => {
-                        let (_, vals): (u64, Vec<String>) = redis::cmd("HSCAN")
-                            .arg(key)
-                            .arg(0u64)
-                            .arg("COUNT")
-                            .arg(remaining)
-                            .query(conn_like)
-                            .unwrap_or((0, Vec::new()));
-                        for chunk in vals.chunks(2).take(remaining) {
-                            if chunk.len() == 2 {
-                                result.push(vec![key.clone(), chunk[0].clone(), chunk[1].clone()]);
-                            }
-                        }
-                    }
-                    "list" => {
-                        let vals: Vec<String> = redis::cmd("LRANGE")
-                            .arg(key)
-                            .arg(0i64)
-                            .arg((remaining as i64) - 1)
-                            .query(conn_like)
-                            .unwrap_or_default();
-                        for v in vals {
-                            result.push(vec![key.clone(), v]);
-                        }
-                    }
-                    "set" => {
-                        let (_, vals): (u64, Vec<String>) = redis::cmd("SSCAN")
-                            .arg(key)
-                            .arg(0u64)
-                            .arg("COUNT")
-                            .arg(remaining)
-                            .query(conn_like)
-                            .unwrap_or((0, Vec::new()));
-                        for v in vals.into_iter().take(remaining) {
-                            result.push(vec![key.clone(), v]);
-                        }
-                    }
-                    "zset" => {
-                        let vals: Vec<String> = redis::cmd("ZRANGE")
-                            .arg(key)
-                            .arg(0i64)
-                            .arg((remaining as i64) - 1)
-                            .arg("WITHSCORES")
-                            .query(conn_like)
-                            .unwrap_or_default();
-                        for chunk in vals.chunks(2) {
-                            if chunk.len() == 2 {
-                                result.push(vec![key.clone(), chunk[1].clone(), chunk[0].clone()]);
-                            }
-                        }
-                    }
-                    _ => {
-                        result.push(vec![key.clone()]);
-                    }
-                }
-            }
-        }
-        result
-    } else {
-        let limit_info = LimitOffsetInfo {
-            limit: Some(targrows as usize),
-            offset: None,
-        };
-        let _ = table_type.load_data(conn_like, &key_prefix, None, &limit_info);
-
-        let mut result = Vec::new();
-        let len = table_type.data_len();
-        for i in 0..len {
-            if let Some(row_data) = table_type.get_row(i) {
-                result.push(row_data.into_iter().map(|c| c.into_owned()).collect());
-            }
-        }
-        result
-    };
-
-    let num_rows = sample_data.len().min(targrows as usize);
-    *totalrows = num_rows as f64;
-    *totaldeadrows = 0.0;
-
-    let mut actual = 0i32;
-    for (idx, row_data) in sample_data.iter().take(num_rows).enumerate() {
-        let mut values: Vec<pg_sys::Datum> = Vec::with_capacity(natts);
-        let mut nulls: Vec<bool> = Vec::with_capacity(natts);
-
-        for col_idx in 0..natts {
-            if col_idx < row_data.len() {
-                let attr = tuple_desc_attr(tupdesc, col_idx);
-                let typid = (*attr).atttypid;
-                let datum = get_datum(&row_data[col_idx], typid);
-                values.push(datum);
-                nulls.push(false);
-            } else {
-                values.push(pg_sys::Datum::from(0));
-                nulls.push(true);
-            }
-        }
-
-        let tuple = pg_sys::heap_form_tuple(tupdesc, values.as_mut_ptr(), nulls.as_mut_ptr());
-        *rows.add(idx) = tuple;
-        actual += 1;
-    }
-
-    actual
-}
-
-/// Extract join column indices from the join restrictlist.
-/// Returns (outer_col_0based, inner_col_0based) if an equality condition is found
-/// between a Var on the outer rel and a Var on the inner rel.
-unsafe fn extract_join_columns(
-    extra: *mut pgrx::pg_sys::JoinPathExtraData,
-    outerrel: *mut pgrx::pg_sys::RelOptInfo,
-    innerrel: *mut pgrx::pg_sys::RelOptInfo,
-) -> Option<(usize, usize)> {
-    if extra.is_null() {
-        return None;
-    }
-
-    let restrictlist = (*extra).restrictlist;
-    if restrictlist.is_null() {
-        return None;
-    }
-
-    let outer_relids = (*outerrel).relids;
-    let inner_relids = (*innerrel).relids;
-
-    let restrict_items: Vec<*mut pg_sys::Node> = pgrx::memcx::current_context(|mcx| {
-        let list = pg_list_to_rust_list::<*mut std::ffi::c_void>(restrictlist, mcx);
-        list.iter().map(|item| *item as *mut pg_sys::Node).collect()
-    });
-
-    for node in &restrict_items {
-        let node = *node;
-        if node.is_null() {
-            continue;
-        }
-
-        // Unwrap RestrictInfo wrapper
-        let clause = if (*node).type_ == pg_sys::NodeTag::T_RestrictInfo {
-            let ri = node as *mut pg_sys::RestrictInfo;
-            (*ri).clause as *mut pg_sys::Node
-        } else {
-            node
-        };
-
-        if clause.is_null() || (*clause).type_ != pg_sys::NodeTag::T_OpExpr {
-            continue;
-        }
-
-        let op_expr = &*(clause as *mut pg_sys::OpExpr);
-
-        // Must be a merge-joinable (equality) operator with exactly 2 args
-        if !pg_sys::op_mergejoinable(op_expr.opno, pg_sys::InvalidOid) {
-            continue;
-        }
-
-        if pg_sys::list_length(op_expr.args) != 2 {
-            continue;
-        }
-
-        let left_arg = pg_sys::list_nth(op_expr.args, 0) as *mut pg_sys::Node;
-        let right_arg = pg_sys::list_nth(op_expr.args, 1) as *mut pg_sys::Node;
-
-        if left_arg.is_null() || right_arg.is_null() {
-            continue;
-        }
-
-        // Both args must be Var nodes
-        if (*left_arg).type_ != pg_sys::NodeTag::T_Var
-            || (*right_arg).type_ != pg_sys::NodeTag::T_Var
-        {
-            continue;
-        }
-
-        let left_var = &*(left_arg as *mut pg_sys::Var);
-        let right_var = &*(right_arg as *mut pg_sys::Var);
-
-        // Check which var belongs to outer/inner
-        let left_in_outer = pg_sys::bms_is_member(left_var.varno as i32, outer_relids);
-        let left_in_inner = pg_sys::bms_is_member(left_var.varno as i32, inner_relids);
-        let right_in_outer = pg_sys::bms_is_member(right_var.varno as i32, outer_relids);
-        let right_in_inner = pg_sys::bms_is_member(right_var.varno as i32, inner_relids);
-
-        if left_in_outer && right_in_inner && left_var.varattno > 0 && right_var.varattno > 0 {
-            let outer_col = (left_var.varattno - 1) as usize;
-            let inner_col = (right_var.varattno - 1) as usize;
-            return Some((outer_col, inner_col));
-        } else if right_in_outer && left_in_inner && right_var.varattno > 0 && left_var.varattno > 0
-        {
-            let outer_col = (right_var.varattno - 1) as usize;
-            let inner_col = (left_var.varattno - 1) as usize;
-            return Some((outer_col, inner_col));
-        }
-    }
-
-    None
-}
-
-#[pg_guard]
-unsafe extern "C-unwind" fn get_foreign_join_paths(
-    root: *mut pgrx::pg_sys::PlannerInfo,
-    joinrel: *mut pgrx::pg_sys::RelOptInfo,
-    outerrel: *mut pgrx::pg_sys::RelOptInfo,
-    innerrel: *mut pgrx::pg_sys::RelOptInfo,
-    jointype: pgrx::pg_sys::JoinType::Type,
-    _extra: *mut pgrx::pg_sys::JoinPathExtraData,
-) {
-    log!("---> get_foreign_join_paths");
-
-    if jointype != pgrx::pg_sys::JoinType::JOIN_INNER
-        && jointype != pgrx::pg_sys::JoinType::JOIN_LEFT
-    {
-        log!("Unsupported join type for pushdown");
-        return;
-    }
-
-    let outer_state_ptr = (*outerrel).fdw_private as *mut RedisFdwState;
-    let inner_state_ptr = (*innerrel).fdw_private as *mut RedisFdwState;
-
-    if outer_state_ptr.is_null() || inner_state_ptr.is_null() {
-        log!("One or both relations lack FDW state, cannot push down join");
-        return;
-    }
-
-    let outer_state = &*outer_state_ptr;
-    let inner_state = &*inner_state_ptr;
-
-    if outer_state.host_port != inner_state.host_port {
-        log!(
-            "Relations on different servers ({} vs {}), cannot push down",
-            outer_state.host_port,
-            inner_state.host_port
-        );
-        return;
-    }
-
-    // Multi-key pattern tables use SCAN-based iteration; pushdown not supported
-    if outer_state.is_multi_key || inner_state.is_multi_key {
-        log!("Multi-key pattern table detected, join pushdown not supported");
-        return;
-    }
-
-    // Stream tables have variable-width rows; pushdown not supported
-    if matches!(outer_state.table_type, RedisTableType::Stream(_))
-        || matches!(inner_state.table_type, RedisTableType::Stream(_))
-    {
-        log!("Stream table detected, join pushdown not supported");
-        return;
-    }
-
-    // Skip pushdown when either base relation has WHERE restrictions.
-    // Our pushdown fetches all data from both sides; PG's base restrictions
-    // assume the base scan already filtered rows. Without a way to re-evaluate
-    // base quals in the join scan, fall back to nested-loop which handles them.
-    if !(*outerrel).baserestrictinfo.is_null()
-        && pg_sys::list_length((*outerrel).baserestrictinfo) > 0
-    {
-        log!("Outer relation has base restrictions, skipping join pushdown");
-        return;
-    }
-    if !(*innerrel).baserestrictinfo.is_null()
-        && pg_sys::list_length((*innerrel).baserestrictinfo) > 0
-    {
-        log!("Inner relation has base restrictions, skipping join pushdown");
-        return;
-    }
-
-    // Extract join columns from the restrictlist in JoinPathExtraData
-    let (join_col_outer, join_col_inner) = match extract_join_columns(_extra, outerrel, innerrel) {
-        Some(cols) => cols,
-        None => {
-            log!("No equality join clause found between FDW rels, cannot push down");
-            return;
-        }
-    };
-
-    log!(
-        "Detected join columns: outer={}, inner={}",
-        join_col_outer,
-        join_col_inner
-    );
-
-    let outer_rows = (*outerrel).rows;
-    let inner_rows = (*innerrel).rows;
-
-    use crate::query::cost_estimation::costs;
-    let network_cost = costs::NETWORK_ROUND_TRIP * 4.0
-        + (outer_rows + inner_rows) * costs::NETWORK_TRANSFER_PER_ROW;
-    let build_cost = inner_rows.min(outer_rows) * costs::CPU_TUPLE_COST;
-    let probe_cost = inner_rows.max(outer_rows) * costs::CPU_TUPLE_COST;
-    let startup_cost = network_cost + build_cost;
-    let total_cost = startup_cost + probe_cost;
-
-    let joinrel_rows = outer_rows.min(inner_rows);
-
-    // Store outer+inner state pointers, jointype, join columns, and relids
-    let fdw_private = serialize_join_info_to_list(&[
-        outer_state_ptr as i64,
-        inner_state_ptr as i64,
-        jointype as i64,
-        join_col_outer as i64,
-        join_col_inner as i64,
-        (*outerrel).relid as i64,
-        (*innerrel).relid as i64,
-    ]);
-
-    let path = pgrx::pg_sys::create_foreign_join_path(
-        root,
-        joinrel,
-        ptr::null_mut(),
-        joinrel_rows,
-        #[cfg(feature = "pg18")]
-        0,
-        startup_cost,
-        total_cost,
-        ptr::null_mut(),
-        (*joinrel).lateral_relids,
-        ptr::null_mut(),
-        #[cfg(any(feature = "pg17", feature = "pg18"))]
-        ptr::null_mut(),
-        fdw_private,
-    );
-    pgrx::pg_sys::add_path(joinrel, path as *mut pgrx::pg_sys::Path);
 }

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -244,11 +244,11 @@ unsafe extern "C-unwind" fn get_foreign_plan(
             let left_is_mine = pg_sys::bms_is_member(left_var.varno as i32, my_relids);
             let right_is_mine = pg_sys::bms_is_member(right_var.varno as i32, my_relids);
 
-            if left_is_mine && !right_is_mine {
+            if left_is_mine && !right_is_mine && left_var.varattno > 0 {
                 param_col_idx = (left_var.varattno - 1) as usize;
                 fdw_exprs = pg_sys::lappend(fdw_exprs, right_arg as *mut std::ffi::c_void);
                 break;
-            } else if right_is_mine && !left_is_mine {
+            } else if right_is_mine && !left_is_mine && right_var.varattno > 0 {
                 param_col_idx = (right_var.varattno - 1) as usize;
                 fdw_exprs = pg_sys::lappend(fdw_exprs, left_arg as *mut std::ffi::c_void);
                 break;

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -182,11 +182,14 @@ extern "C-unwind" fn get_foreign_paths(
 
         if !state_ptr.is_null() {
             let state = &*state_ptr;
-            let supports_param = matches!(
-                state.table_type,
-                RedisTableType::Hash(_) | RedisTableType::Set(_) | RedisTableType::ZSet(_)
-            );
-            if supports_param && !state.is_multi_key {
+            let supports_param = match &state.table_type {
+                RedisTableType::Hash(_) | RedisTableType::Set(_) | RedisTableType::ZSet(_) => {
+                    !state.is_multi_key
+                }
+                RedisTableType::String(_) => state.is_multi_key,
+                _ => false,
+            };
+            if supports_param {
                 add_parameterized_paths(_root, baserel, state);
             }
         }

--- a/src/core/join.rs
+++ b/src/core/join.rs
@@ -1,0 +1,440 @@
+use crate::{
+    core::{column_utils::state_from_ptr, state_manager::RedisFdwState},
+    join::types::{RedisJoinState, RedisJoinType},
+    query::cost_estimation::costs,
+    tables::types::RedisTableType,
+    utils::{helpers::*, memory::create_wrappers_memctx},
+};
+use pgrx::{prelude::*, PgMemoryContexts};
+use std::ptr;
+
+pub(crate) unsafe fn add_parameterized_paths(
+    root: *mut pg_sys::PlannerInfo,
+    baserel: *mut pg_sys::RelOptInfo,
+    state: &RedisFdwState,
+) {
+    let joininfo = (*baserel).joininfo;
+    if joininfo.is_null() {
+        return;
+    }
+
+    let my_relids = (*baserel).relids;
+    let list_len = pg_sys::list_length(joininfo);
+
+    for i in 0..list_len {
+        let cell = pg_sys::list_nth(joininfo, i) as *mut pg_sys::RestrictInfo;
+        if cell.is_null() {
+            continue;
+        }
+
+        let ri = &*cell;
+        let clause = ri.clause as *mut pg_sys::Node;
+        if clause.is_null() || (*clause).type_ != pg_sys::NodeTag::T_OpExpr {
+            continue;
+        }
+
+        let op_expr = &*(clause as *mut pg_sys::OpExpr);
+        if !pg_sys::op_mergejoinable(op_expr.opno, pg_sys::InvalidOid) {
+            continue;
+        }
+        if pg_sys::list_length(op_expr.args) != 2 {
+            continue;
+        }
+
+        let left_arg = pg_sys::list_nth(op_expr.args, 0) as *mut pg_sys::Node;
+        let right_arg = pg_sys::list_nth(op_expr.args, 1) as *mut pg_sys::Node;
+        if left_arg.is_null() || right_arg.is_null() {
+            continue;
+        }
+        if (*left_arg).type_ != pg_sys::NodeTag::T_Var
+            || (*right_arg).type_ != pg_sys::NodeTag::T_Var
+        {
+            continue;
+        }
+
+        let left_var = &*(left_arg as *mut pg_sys::Var);
+        let right_var = &*(right_arg as *mut pg_sys::Var);
+
+        let (my_col_attno, outer_relid) = if pg_sys::bms_is_member(left_var.varno as i32, my_relids)
+            && !pg_sys::bms_is_member(right_var.varno as i32, my_relids)
+        {
+            (left_var.varattno, right_var.varno)
+        } else if pg_sys::bms_is_member(right_var.varno as i32, my_relids)
+            && !pg_sys::bms_is_member(left_var.varno as i32, my_relids)
+        {
+            (right_var.varattno, left_var.varno)
+        } else {
+            continue;
+        };
+
+        if my_col_attno <= 0 {
+            continue;
+        }
+        let my_col_idx = (my_col_attno - 1) as usize;
+
+        let valid = match &state.table_type {
+            RedisTableType::Hash(_) => my_col_idx == 0,
+            RedisTableType::Set(_) => my_col_idx == 0,
+            RedisTableType::ZSet(_) => my_col_idx == 0,
+            _ => false,
+        };
+        if !valid {
+            continue;
+        }
+
+        #[allow(clippy::unnecessary_cast)]
+        let required_outer = pg_sys::bms_make_singleton(outer_relid as i32);
+
+        let param_path = pg_sys::create_foreignscan_path(
+            root,
+            baserel,
+            ptr::null_mut(),
+            1.0,
+            #[cfg(feature = "pg18")]
+            0,
+            1.0,
+            2.0,
+            ptr::null_mut(),
+            required_outer,
+            ptr::null_mut(),
+            #[cfg(any(feature = "pg17", feature = "pg18"))]
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+        pg_sys::add_path(baserel, param_path as *mut pg_sys::Path);
+        log!(
+            "Added parameterized path for col {} with outer relid {}",
+            my_col_idx,
+            outer_relid
+        );
+    }
+}
+
+pub(crate) unsafe fn plan_foreign_join(
+    _root: *mut pgrx::pg_sys::PlannerInfo,
+    joinrel: *mut pgrx::pg_sys::RelOptInfo,
+    best_path: *mut pgrx::pg_sys::ForeignPath,
+    tlist: *mut pgrx::pg_sys::List,
+    scan_clauses: *mut pgrx::pg_sys::List,
+    outer_plan: *mut pgrx::pg_sys::Plan,
+) -> *mut pgrx::pg_sys::ForeignScan {
+    log!("---> plan_foreign_join");
+
+    let path_private = (*best_path).fdw_private;
+    let outer_state_ptr = deserialize_nth_ptr_from_list(path_private, 0) as *mut RedisFdwState;
+    let inner_state_ptr = deserialize_nth_ptr_from_list(path_private, 1) as *mut RedisFdwState;
+
+    if outer_state_ptr.is_null() || inner_state_ptr.is_null() {
+        pgrx::error!("Join plan: missing outer/inner state in fdw_private");
+    }
+
+    let outer_state = &*outer_state_ptr;
+    let inner_state = &*inner_state_ptr;
+
+    let jointype_val = deserialize_nth_ptr_from_list(path_private, 2) as i64;
+    let join_type = if jointype_val == pgrx::pg_sys::JoinType::JOIN_LEFT as i64 {
+        RedisJoinType::Left
+    } else {
+        RedisJoinType::Inner
+    };
+
+    let join_col_outer = deserialize_nth_ptr_from_list(path_private, 3) as usize;
+    let join_col_inner = deserialize_nth_ptr_from_list(path_private, 4) as usize;
+
+    let outer_relid = deserialize_nth_ptr_from_list(path_private, 5) as pg_sys::Index;
+    let inner_relid = deserialize_nth_ptr_from_list(path_private, 6) as pg_sys::Index;
+
+    let join_state = RedisJoinState::new(
+        outer_state.table_type.clone(),
+        inner_state.table_type.clone(),
+        outer_state.table_key_prefix.clone(),
+        inner_state.table_key_prefix.clone(),
+        join_type,
+        join_col_outer,
+        join_col_inner,
+    );
+
+    let ctx_name = "Wrappers_join_scan";
+    let ctx = create_wrappers_memctx(ctx_name);
+    let mut state = RedisFdwState::new(ctx);
+
+    state.host_port = outer_state.host_port.clone();
+    state.database = outer_state.database;
+    state.opts = outer_state.opts.clone();
+    state.is_join_scan = true;
+    state.join_state = Some(join_state);
+
+    let state_ptr = PgMemoryContexts::For(ctx).leak_and_drop_on_delete(state);
+    (*joinrel).fdw_private = state_ptr as *mut std::os::raw::c_void;
+
+    let outer_ncols = crate::join::foreign_join::expected_columns_for_type(&outer_state.table_type);
+    let inner_ncols = crate::join::foreign_join::expected_columns_for_type(&inner_state.table_type);
+
+    let mut fdw_scan_tlist: *mut pg_sys::List = ptr::null_mut();
+    let mut resno: i16 = 1;
+
+    for attno in 1..=(outer_ncols as i16) {
+        let var = pg_sys::makeVar(
+            outer_relid as _,
+            attno,
+            pg_sys::TEXTOID,
+            -1,
+            pg_sys::DEFAULT_COLLATION_OID,
+            0,
+        );
+        let tle = pg_sys::makeTargetEntry(var as *mut pg_sys::Expr, resno, ptr::null_mut(), false);
+        fdw_scan_tlist = pg_sys::lappend(fdw_scan_tlist, tle as *mut std::ffi::c_void);
+        resno += 1;
+    }
+    for attno in 1..=(inner_ncols as i16) {
+        let var = pg_sys::makeVar(
+            inner_relid as _,
+            attno,
+            pg_sys::TEXTOID,
+            -1,
+            pg_sys::DEFAULT_COLLATION_OID,
+            0,
+        );
+        let tle = pg_sys::makeTargetEntry(var as *mut pg_sys::Expr, resno, ptr::null_mut(), false);
+        fdw_scan_tlist = pg_sys::lappend(fdw_scan_tlist, tle as *mut std::ffi::c_void);
+        resno += 1;
+    }
+
+    let fdw_private = serialize_ptr_to_list(state_ptr as *mut std::os::raw::c_void);
+    let local_quals = pg_sys::extract_actual_clauses(scan_clauses, false);
+
+    pgrx::pg_sys::make_foreignscan(
+        tlist,
+        local_quals,
+        0,
+        ptr::null_mut(),
+        fdw_private as _,
+        fdw_scan_tlist,
+        ptr::null_mut(),
+        outer_plan,
+    )
+}
+
+pub(crate) unsafe fn begin_foreign_join_scan(
+    node: *mut pgrx::pg_sys::ForeignScanState,
+    plan: *mut pg_sys::ForeignScan,
+) {
+    log!("---> begin_foreign_join_scan");
+    let state_ptr = deserialize_ptr_from_list((*plan).fdw_private as _);
+    let state = state_from_ptr(state_ptr);
+
+    if state.redis_connection.is_none() {
+        if let Err(e) = state.init_redis_connection_from_options() {
+            pgrx::error!("Failed to connect to Redis for join scan: {}", e);
+        }
+    }
+
+    if let Some(ref mut join_state) = state.join_state {
+        join_state.connection = state.redis_connection.take();
+    }
+
+    (*node).fdw_state = state_ptr;
+}
+
+unsafe fn extract_join_columns(
+    extra: *mut pgrx::pg_sys::JoinPathExtraData,
+    outerrel: *mut pgrx::pg_sys::RelOptInfo,
+    innerrel: *mut pgrx::pg_sys::RelOptInfo,
+) -> Option<(usize, usize)> {
+    if extra.is_null() {
+        return None;
+    }
+
+    let restrictlist = (*extra).restrictlist;
+    if restrictlist.is_null() {
+        return None;
+    }
+
+    let outer_relids = (*outerrel).relids;
+    let inner_relids = (*innerrel).relids;
+
+    let restrict_items: Vec<*mut pg_sys::Node> = pgrx::memcx::current_context(|mcx| {
+        let list = pg_list_to_rust_list::<*mut std::ffi::c_void>(restrictlist, mcx);
+        list.iter().map(|item| *item as *mut pg_sys::Node).collect()
+    });
+
+    for node in &restrict_items {
+        let node = *node;
+        if node.is_null() {
+            continue;
+        }
+
+        let clause = if (*node).type_ == pg_sys::NodeTag::T_RestrictInfo {
+            let ri = node as *mut pg_sys::RestrictInfo;
+            (*ri).clause as *mut pg_sys::Node
+        } else {
+            node
+        };
+
+        if clause.is_null() || (*clause).type_ != pg_sys::NodeTag::T_OpExpr {
+            continue;
+        }
+
+        let op_expr = &*(clause as *mut pg_sys::OpExpr);
+
+        if !pg_sys::op_mergejoinable(op_expr.opno, pg_sys::InvalidOid) {
+            continue;
+        }
+
+        if pg_sys::list_length(op_expr.args) != 2 {
+            continue;
+        }
+
+        let left_arg = pg_sys::list_nth(op_expr.args, 0) as *mut pg_sys::Node;
+        let right_arg = pg_sys::list_nth(op_expr.args, 1) as *mut pg_sys::Node;
+
+        if left_arg.is_null() || right_arg.is_null() {
+            continue;
+        }
+
+        if (*left_arg).type_ != pg_sys::NodeTag::T_Var
+            || (*right_arg).type_ != pg_sys::NodeTag::T_Var
+        {
+            continue;
+        }
+
+        let left_var = &*(left_arg as *mut pg_sys::Var);
+        let right_var = &*(right_arg as *mut pg_sys::Var);
+
+        let left_in_outer = pg_sys::bms_is_member(left_var.varno as i32, outer_relids);
+        let left_in_inner = pg_sys::bms_is_member(left_var.varno as i32, inner_relids);
+        let right_in_outer = pg_sys::bms_is_member(right_var.varno as i32, outer_relids);
+        let right_in_inner = pg_sys::bms_is_member(right_var.varno as i32, inner_relids);
+
+        if left_in_outer && right_in_inner && left_var.varattno > 0 && right_var.varattno > 0 {
+            let outer_col = (left_var.varattno - 1) as usize;
+            let inner_col = (right_var.varattno - 1) as usize;
+            return Some((outer_col, inner_col));
+        } else if right_in_outer && left_in_inner && right_var.varattno > 0 && left_var.varattno > 0
+        {
+            let outer_col = (right_var.varattno - 1) as usize;
+            let inner_col = (left_var.varattno - 1) as usize;
+            return Some((outer_col, inner_col));
+        }
+    }
+
+    None
+}
+
+#[pg_guard]
+pub(crate) unsafe extern "C-unwind" fn get_foreign_join_paths(
+    root: *mut pgrx::pg_sys::PlannerInfo,
+    joinrel: *mut pgrx::pg_sys::RelOptInfo,
+    outerrel: *mut pgrx::pg_sys::RelOptInfo,
+    innerrel: *mut pgrx::pg_sys::RelOptInfo,
+    jointype: pgrx::pg_sys::JoinType::Type,
+    _extra: *mut pgrx::pg_sys::JoinPathExtraData,
+) {
+    log!("---> get_foreign_join_paths");
+
+    if jointype != pgrx::pg_sys::JoinType::JOIN_INNER
+        && jointype != pgrx::pg_sys::JoinType::JOIN_LEFT
+    {
+        log!("Unsupported join type for pushdown");
+        return;
+    }
+
+    let outer_state_ptr = (*outerrel).fdw_private as *mut RedisFdwState;
+    let inner_state_ptr = (*innerrel).fdw_private as *mut RedisFdwState;
+
+    if outer_state_ptr.is_null() || inner_state_ptr.is_null() {
+        log!("One or both relations lack FDW state, cannot push down join");
+        return;
+    }
+
+    let outer_state = &*outer_state_ptr;
+    let inner_state = &*inner_state_ptr;
+
+    if outer_state.host_port != inner_state.host_port {
+        log!(
+            "Relations on different servers ({} vs {}), cannot push down",
+            outer_state.host_port,
+            inner_state.host_port
+        );
+        return;
+    }
+
+    if outer_state.is_multi_key || inner_state.is_multi_key {
+        log!("Multi-key pattern table detected, join pushdown not supported");
+        return;
+    }
+
+    if matches!(outer_state.table_type, RedisTableType::Stream(_))
+        || matches!(inner_state.table_type, RedisTableType::Stream(_))
+    {
+        log!("Stream table detected, join pushdown not supported");
+        return;
+    }
+
+    if !(*outerrel).baserestrictinfo.is_null()
+        && pg_sys::list_length((*outerrel).baserestrictinfo) > 0
+    {
+        log!("Outer relation has base restrictions, skipping join pushdown");
+        return;
+    }
+    if !(*innerrel).baserestrictinfo.is_null()
+        && pg_sys::list_length((*innerrel).baserestrictinfo) > 0
+    {
+        log!("Inner relation has base restrictions, skipping join pushdown");
+        return;
+    }
+
+    let (join_col_outer, join_col_inner) = match extract_join_columns(_extra, outerrel, innerrel) {
+        Some(cols) => cols,
+        None => {
+            log!("No equality join clause found between FDW rels, cannot push down");
+            return;
+        }
+    };
+
+    log!(
+        "Detected join columns: outer={}, inner={}",
+        join_col_outer,
+        join_col_inner
+    );
+
+    let outer_rows = (*outerrel).rows;
+    let inner_rows = (*innerrel).rows;
+
+    let network_cost = costs::NETWORK_ROUND_TRIP * 4.0
+        + (outer_rows + inner_rows) * costs::NETWORK_TRANSFER_PER_ROW;
+    let build_cost = inner_rows.min(outer_rows) * costs::CPU_TUPLE_COST;
+    let probe_cost = inner_rows.max(outer_rows) * costs::CPU_TUPLE_COST;
+    let startup_cost = network_cost + build_cost;
+    let total_cost = startup_cost + probe_cost;
+
+    let joinrel_rows = outer_rows.min(inner_rows);
+
+    let fdw_private = serialize_join_info_to_list(&[
+        outer_state_ptr as i64,
+        inner_state_ptr as i64,
+        jointype as i64,
+        join_col_outer as i64,
+        join_col_inner as i64,
+        (*outerrel).relid as i64,
+        (*innerrel).relid as i64,
+    ]);
+
+    let path = pgrx::pg_sys::create_foreign_join_path(
+        root,
+        joinrel,
+        ptr::null_mut(),
+        joinrel_rows,
+        #[cfg(feature = "pg18")]
+        0,
+        startup_cost,
+        total_cost,
+        ptr::null_mut(),
+        (*joinrel).lateral_relids,
+        ptr::null_mut(),
+        #[cfg(any(feature = "pg17", feature = "pg18"))]
+        ptr::null_mut(),
+        fdw_private,
+    );
+    pgrx::pg_sys::add_path(joinrel, path as *mut pgrx::pg_sys::Path);
+}

--- a/src/core/join.rs
+++ b/src/core/join.rs
@@ -92,8 +92,8 @@ pub(crate) unsafe fn add_parameterized_paths(
             1.0,
             #[cfg(feature = "pg18")]
             0,
-            1.0,
-            2.0,
+            costs::NETWORK_ROUND_TRIP,
+            costs::NETWORK_ROUND_TRIP + costs::CPU_TUPLE_COST,
             ptr::null_mut(),
             required_outer,
             ptr::null_mut(),

--- a/src/core/join.rs
+++ b/src/core/join.rs
@@ -76,6 +76,7 @@ pub(crate) unsafe fn add_parameterized_paths(
             RedisTableType::Hash(_) => my_col_idx == 0,
             RedisTableType::Set(_) => my_col_idx == 0,
             RedisTableType::ZSet(_) => my_col_idx == 0,
+            RedisTableType::String(_) if state.is_multi_key => my_col_idx == 0,
             _ => false,
         };
         if !valid {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,12 +1,10 @@
-/// Core FDW functionality module
-///
-/// This module contains the essential components for the Redis Foreign Data Wrapper:
-/// - Connection factory for creating and configuring Redis connections
-/// - Global connection pool manager for efficient connection reuse
-/// - FDW handlers that integrate with PostgreSQL's foreign data wrapper infrastructure
-/// - State management for query execution
+pub mod column_utils;
 pub mod connection_factory;
+pub mod explain;
 pub mod handlers;
+pub mod join;
 pub mod pool_manager;
+pub mod schema_import;
 pub mod state_manager;
+pub mod truncate;
 pub mod validator;

--- a/src/core/schema_import.rs
+++ b/src/core/schema_import.rs
@@ -1,0 +1,498 @@
+use crate::{
+    core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory},
+    core::state_manager::is_multi_key_pattern,
+    query::limit::LimitOffsetInfo,
+    tables::types::RedisTableType,
+    utils::helpers::*,
+};
+use pgrx::prelude::*;
+use std::ffi::CString;
+use std::ptr;
+
+#[pg_guard]
+pub(crate) unsafe extern "C-unwind" fn import_foreign_schema(
+    stmt: *mut pg_sys::ImportForeignSchemaStmt,
+    server_oid: pg_sys::Oid,
+) -> *mut pg_sys::List {
+    log!("---> import_foreign_schema");
+    use std::collections::HashMap as StdHashMap;
+
+    let server = pg_sys::GetForeignServer(server_oid);
+    let mut options: StdHashMap<String, String> = StdHashMap::new();
+
+    pgrx::memcx::current_context(|mcx| {
+        if !(*server).options.is_null() {
+            let opts_list = pg_list_to_rust_list::<*mut std::ffi::c_void>((*server).options, mcx);
+            for option in opts_list.iter() {
+                let def_elem = (*option).cast::<pg_sys::DefElem>();
+                if !def_elem.is_null() {
+                    options.insert(
+                        string_from_cstr((*def_elem).defname),
+                        string_from_cstr(pg_sys::defGetString(def_elem)),
+                    );
+                }
+            }
+        }
+    });
+
+    let config = match RedisConnectionConfig::from_options(&options) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to create Redis config for import: {}", e);
+        }
+    };
+
+    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to connect to Redis for import: {}", e);
+        }
+    };
+
+    let conn_like = conn.as_connection_like_mut();
+
+    let mut all_keys: Vec<String> = Vec::new();
+    let mut cursor: u64 = 0;
+    let max_keys: usize = 10_000;
+    loop {
+        pgrx::check_for_interrupts!();
+        let (new_cursor, keys): (u64, Vec<String>) = match redis::cmd("SCAN")
+            .arg(cursor)
+            .arg("COUNT")
+            .arg(1000u32)
+            .query(conn_like)
+        {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Redis SCAN error during import: {}", e);
+            }
+        };
+
+        all_keys.extend(keys);
+        cursor = new_cursor;
+        if cursor == 0 || all_keys.len() >= max_keys {
+            break;
+        }
+    }
+
+    if all_keys.len() > max_keys {
+        all_keys.truncate(max_keys);
+    }
+
+    if all_keys.is_empty() {
+        return ptr::null_mut();
+    }
+
+    let mut pipe = redis::pipe();
+    for key in &all_keys {
+        pipe.cmd("TYPE").arg(key);
+    }
+    let types: Vec<String> = match pipe.query(conn_like) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Redis TYPE pipeline error during import: {}", e);
+        }
+    };
+
+    let mut groups: StdHashMap<String, String> = StdHashMap::new();
+    for (key, redis_type) in all_keys.iter().zip(types.iter()) {
+        if redis_type == "none" {
+            continue;
+        }
+        let prefix = derive_key_prefix(key);
+        groups.entry(prefix).or_insert_with(|| redis_type.clone());
+    }
+
+    let list_type = (*stmt).list_type;
+    let mut filter_names: Vec<String> = Vec::new();
+    if !(*stmt).table_list.is_null() {
+        pgrx::memcx::current_context(|mcx| {
+            let table_list = pgrx::list::List::<*mut std::ffi::c_void>::downcast_ptr_in_memcx(
+                (*stmt).table_list,
+                mcx,
+            )
+            .expect("Failed to downcast table_list");
+            for item in table_list.iter() {
+                let rv = *item as *mut pg_sys::RangeVar;
+                if !rv.is_null() && !(*rv).relname.is_null() {
+                    filter_names.push(string_from_cstr((*rv).relname));
+                }
+            }
+        });
+    }
+
+    let server_name = string_from_cstr((*stmt).server_name);
+    let mut result_list: *mut pg_sys::List = ptr::null_mut();
+
+    for (prefix, redis_type) in &groups {
+        let table_name = sanitize_table_name(prefix);
+
+        match list_type {
+            pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_LIMIT_TO
+                if !filter_names.contains(&table_name) =>
+            {
+                continue;
+            }
+            pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_EXCEPT
+                if filter_names.contains(&table_name) =>
+            {
+                continue;
+            }
+            _ => {}
+        }
+
+        let columns = columns_for_type(redis_type);
+        let key_pattern = format!("{}*", prefix);
+        let database_str = config.database.to_string();
+
+        let quoted_table = table_name.replace('"', "\"\"");
+        let quoted_server = server_name.replace('"', "\"\"");
+        let escaped_prefix = key_pattern.replace('\'', "''");
+
+        let ddl = format!(
+            "CREATE FOREIGN TABLE \"{}\" ({}) SERVER \"{}\" OPTIONS (database '{}', table_type '{}', table_key_prefix '{}')",
+            quoted_table, columns, quoted_server, database_str, redis_type, escaped_prefix
+        );
+
+        let ddl_cstr = match CString::new(ddl) {
+            Ok(c) => c,
+            Err(_) => {
+                error!("import_foreign_schema: table name contains null byte");
+            }
+        };
+        let pg_str = pg_sys::pstrdup(ddl_cstr.as_ptr());
+        result_list = pg_sys::lappend(result_list, pg_str as *mut std::ffi::c_void);
+    }
+
+    result_list
+}
+
+#[pg_guard]
+pub(crate) unsafe extern "C-unwind" fn analyze_foreign_table(
+    relation: pg_sys::Relation,
+    func: *mut pg_sys::AcquireSampleRowsFunc,
+    totalpages: *mut pg_sys::BlockNumber,
+) -> bool {
+    log!("---> analyze_foreign_table");
+
+    let relid = (*relation).rd_id;
+    let options = get_foreign_table_options(relid);
+
+    let config = match RedisConnectionConfig::from_options(&options) {
+        Ok(c) => c,
+        Err(e) => {
+            log!("analyze_foreign_table: cannot create config: {}", e);
+            return false;
+        }
+    };
+
+    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
+        Ok(c) => c,
+        Err(e) => {
+            log!("analyze_foreign_table: cannot connect: {}", e);
+            return false;
+        }
+    };
+
+    let conn_like = conn.as_connection_like_mut();
+    let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
+    let table_type = options
+        .get("table_type")
+        .map(|s| s.as_str())
+        .unwrap_or("string");
+
+    let estimated_rows: u64 = if is_multi_key_pattern(&key_prefix) {
+        let mut cursor = 0u64;
+        let mut total_keys = 0u64;
+        let max_iterations = 100;
+        let mut iterations = 0;
+        loop {
+            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&key_prefix)
+                .arg("COUNT")
+                .arg(10000u32)
+                .query(conn_like)
+                .unwrap_or((0, Vec::new()));
+            total_keys += keys.len() as u64;
+            cursor = next_cursor;
+            iterations += 1;
+            if cursor == 0 || iterations >= max_iterations {
+                break;
+            }
+        }
+        total_keys
+    } else {
+        match table_type {
+            "hash" => redis::cmd("HLEN")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "list" => redis::cmd("LLEN")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "set" => redis::cmd("SCARD")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "zset" => redis::cmd("ZCARD")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "stream" => redis::cmd("XLEN")
+                .arg(&key_prefix)
+                .query::<u64>(conn_like)
+                .unwrap_or(0),
+            "string" => {
+                let exists: u64 = redis::cmd("EXISTS")
+                    .arg(&key_prefix)
+                    .query(conn_like)
+                    .unwrap_or(0);
+                exists
+            }
+            _ => 0,
+        }
+    };
+
+    let avg_row_width: u64 = 100;
+    let pages =
+        ((estimated_rows * avg_row_width) / pg_sys::BLCKSZ as u64).max(1) as pg_sys::BlockNumber;
+    *totalpages = pages;
+    *func = Some(acquire_sample_rows);
+    true
+}
+
+#[pg_guard]
+pub(crate) unsafe extern "C-unwind" fn acquire_sample_rows(
+    relation: pg_sys::Relation,
+    _elevel: ::core::ffi::c_int,
+    rows: *mut pg_sys::HeapTuple,
+    targrows: ::core::ffi::c_int,
+    totalrows: *mut f64,
+    totaldeadrows: *mut f64,
+) -> ::core::ffi::c_int {
+    log!("---> acquire_sample_rows (targrows={})", targrows);
+
+    let relid = (*relation).rd_id;
+    let options = get_foreign_table_options(relid);
+    let tupdesc = (*relation).rd_att;
+    let natts = (*tupdesc).natts as usize;
+
+    let config = match RedisConnectionConfig::from_options(&options) {
+        Ok(c) => c,
+        Err(e) => {
+            log!("acquire_sample_rows: cannot create config: {}", e);
+            *totalrows = 0.0;
+            *totaldeadrows = 0.0;
+            return 0;
+        }
+    };
+
+    let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
+        Ok(c) => c,
+        Err(e) => {
+            log!("acquire_sample_rows: cannot connect: {}", e);
+            *totalrows = 0.0;
+            *totaldeadrows = 0.0;
+            return 0;
+        }
+    };
+
+    let conn_like = conn.as_connection_like_mut();
+    let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
+    let table_type_str = options
+        .get("table_type")
+        .map(|s| s.as_str())
+        .unwrap_or("string");
+
+    let mut table_type = RedisTableType::from_str(table_type_str);
+    let is_multi_key = is_multi_key_pattern(&key_prefix);
+
+    let max_per_key = targrows as usize;
+    let sample_data: Vec<Vec<String>> = if is_multi_key {
+        let mut keys = Vec::new();
+        let mut cursor = 0u64;
+        loop {
+            let (next_cursor, batch): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&key_prefix)
+                .arg("COUNT")
+                .arg(targrows as u32)
+                .query(conn_like)
+                .unwrap_or((0, Vec::new()));
+            keys.extend(batch);
+            cursor = next_cursor;
+            if cursor == 0 || keys.len() >= max_per_key {
+                break;
+            }
+        }
+        keys.truncate(max_per_key);
+        let mut result = Vec::new();
+
+        if table_type_str == "string" {
+            let mut pipe = redis::pipe();
+            for key in &keys {
+                pipe.cmd("GET").arg(key);
+            }
+            let vals: Vec<String> = pipe.query(conn_like).unwrap_or_default();
+            for (key, val) in keys.iter().zip(vals.into_iter()) {
+                result.push(vec![key.clone(), val]);
+            }
+        } else {
+            for key in &keys {
+                if result.len() >= max_per_key {
+                    break;
+                }
+                let remaining = max_per_key - result.len();
+                match table_type_str {
+                    "hash" => {
+                        let (_, vals): (u64, Vec<String>) = redis::cmd("HSCAN")
+                            .arg(key)
+                            .arg(0u64)
+                            .arg("COUNT")
+                            .arg(remaining)
+                            .query(conn_like)
+                            .unwrap_or((0, Vec::new()));
+                        for chunk in vals.chunks(2).take(remaining) {
+                            if chunk.len() == 2 {
+                                result.push(vec![key.clone(), chunk[0].clone(), chunk[1].clone()]);
+                            }
+                        }
+                    }
+                    "list" => {
+                        let vals: Vec<String> = redis::cmd("LRANGE")
+                            .arg(key)
+                            .arg(0i64)
+                            .arg((remaining as i64) - 1)
+                            .query(conn_like)
+                            .unwrap_or_default();
+                        for v in vals {
+                            result.push(vec![key.clone(), v]);
+                        }
+                    }
+                    "set" => {
+                        let (_, vals): (u64, Vec<String>) = redis::cmd("SSCAN")
+                            .arg(key)
+                            .arg(0u64)
+                            .arg("COUNT")
+                            .arg(remaining)
+                            .query(conn_like)
+                            .unwrap_or((0, Vec::new()));
+                        for v in vals.into_iter().take(remaining) {
+                            result.push(vec![key.clone(), v]);
+                        }
+                    }
+                    "zset" => {
+                        let vals: Vec<String> = redis::cmd("ZRANGE")
+                            .arg(key)
+                            .arg(0i64)
+                            .arg((remaining as i64) - 1)
+                            .arg("WITHSCORES")
+                            .query(conn_like)
+                            .unwrap_or_default();
+                        for chunk in vals.chunks(2) {
+                            if chunk.len() == 2 {
+                                result.push(vec![key.clone(), chunk[1].clone(), chunk[0].clone()]);
+                            }
+                        }
+                    }
+                    _ => {
+                        result.push(vec![key.clone()]);
+                    }
+                }
+            }
+        }
+        result
+    } else {
+        let limit_info = LimitOffsetInfo {
+            limit: Some(targrows as usize),
+            offset: None,
+        };
+        let _ = table_type.load_data(conn_like, &key_prefix, None, &limit_info);
+
+        let mut result = Vec::new();
+        let len = table_type.data_len();
+        for i in 0..len {
+            if let Some(row_data) = table_type.get_row(i) {
+                result.push(row_data.into_iter().map(|c| c.into_owned()).collect());
+            }
+        }
+        result
+    };
+
+    let num_rows = sample_data.len().min(targrows as usize);
+    *totalrows = num_rows as f64;
+    *totaldeadrows = 0.0;
+
+    let mut actual = 0i32;
+    for (idx, row_data) in sample_data.iter().take(num_rows).enumerate() {
+        let mut values: Vec<pg_sys::Datum> = Vec::with_capacity(natts);
+        let mut nulls: Vec<bool> = Vec::with_capacity(natts);
+
+        for col_idx in 0..natts {
+            if col_idx < row_data.len() {
+                let attr = tuple_desc_attr(tupdesc, col_idx);
+                let typid = (*attr).atttypid;
+                let datum = get_datum(&row_data[col_idx], typid);
+                values.push(datum);
+                nulls.push(false);
+            } else {
+                values.push(pg_sys::Datum::from(0));
+                nulls.push(true);
+            }
+        }
+
+        let tuple = pg_sys::heap_form_tuple(tupdesc, values.as_mut_ptr(), nulls.as_mut_ptr());
+        *rows.add(idx) = tuple;
+        actual += 1;
+    }
+
+    actual
+}
+
+fn derive_key_prefix(key: &str) -> String {
+    if let Some(pos) = key.rfind(':') {
+        key[..=pos].to_string()
+    } else {
+        format!("{}_", key)
+    }
+}
+
+fn sanitize_table_name(prefix: &str) -> String {
+    let mut name: String = prefix
+        .trim_end_matches(':')
+        .trim_end_matches('_')
+        .replace([':', '-', '.'], "_")
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+
+    if name.starts_with(|c: char| c.is_ascii_digit()) {
+        name = format!("t_{}", name);
+    }
+
+    if name.is_empty() {
+        name = "redis_table".to_string();
+    }
+
+    if name.len() > 63 {
+        name.truncate(63);
+    }
+
+    name
+}
+
+fn columns_for_type(redis_type: &str) -> &'static str {
+    match redis_type {
+        "hash" => "key text, field text, value text",
+        "list" => "key text, element text",
+        "set" => "key text, member text",
+        "zset" => "key text, member text, score text",
+        "string" => "key text, value text",
+        "stream" => "stream_id text, field text, value text",
+        _ => "value text",
+    }
+}

--- a/src/core/schema_import.rs
+++ b/src/core/schema_import.rs
@@ -83,16 +83,20 @@ pub(crate) unsafe extern "C-unwind" fn import_foreign_schema(
         return ptr::null_mut();
     }
 
-    let mut pipe = redis::pipe();
-    for key in &all_keys {
-        pipe.cmd("TYPE").arg(key);
-    }
-    let types: Vec<String> = match pipe.query(conn_like) {
-        Ok(t) => t,
-        Err(e) => {
-            error!("Redis TYPE pipeline error during import: {}", e);
+    let mut types: Vec<String> = Vec::with_capacity(all_keys.len());
+    for chunk in all_keys.chunks(1000) {
+        let mut pipe = redis::pipe();
+        for key in chunk {
+            pipe.cmd("TYPE").arg(key);
         }
-    };
+        let chunk_types: Vec<String> = match pipe.query(conn_like) {
+            Ok(t) => t,
+            Err(e) => {
+                error!("Redis TYPE pipeline error during import: {}", e);
+            }
+        };
+        types.extend(chunk_types);
+    }
 
     let mut groups: StdHashMap<String, String> = StdHashMap::new();
     for (key, redis_type) in all_keys.iter().zip(types.iter()) {

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -1095,6 +1095,21 @@ impl RedisFdwState {
                 }
                 false
             }
+            RedisTableType::String(ref mut t) => {
+                // Multi-key mode: param_column == 0 means lookup by key → GET
+                if self.is_multi_key && self.param_column == 0 {
+                    let val: Option<String> = redis::cmd("GET")
+                        .arg(param_value)
+                        .query(conn)
+                        .unwrap_or(None);
+                    if let Some(v) = val {
+                        t.dataset = DataSet::Filtered(vec![param_value.to_string(), v]);
+                        return true;
+                    }
+                    t.dataset = DataSet::Empty;
+                }
+                false
+            }
             _ => false,
         }
     }

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -1049,11 +1049,20 @@ impl RedisFdwState {
             RedisTableType::Hash(ref mut t) => {
                 // param_column == 0 means lookup by field name → HGET
                 if self.param_column == 0 {
-                    let val: Option<String> = redis::cmd("HGET")
+                    let val: Option<String> = match redis::cmd("HGET")
                         .arg(&self.table_key_prefix)
                         .arg(param_value)
                         .query(conn)
-                        .unwrap_or(None);
+                    {
+                        Ok(v) => v,
+                        Err(e) => {
+                            pgrx::warning!(
+                                "redis_fdw: HGET failed during parameterized lookup: {}",
+                                e
+                            );
+                            None
+                        }
+                    };
                     if let Some(v) = val {
                         t.dataset = DataSet::Filtered(vec![param_value.to_string(), v]);
                         return true;
@@ -1063,11 +1072,20 @@ impl RedisFdwState {
                 false
             }
             RedisTableType::Set(ref mut t) => {
-                let exists: bool = redis::cmd("SISMEMBER")
+                let exists: bool = match redis::cmd("SISMEMBER")
                     .arg(&self.table_key_prefix)
                     .arg(param_value)
                     .query(conn)
-                    .unwrap_or(false);
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        pgrx::warning!(
+                            "redis_fdw: SISMEMBER failed during parameterized lookup: {}",
+                            e
+                        );
+                        false
+                    }
+                };
                 if exists {
                     t.dataset = DataSet::Filtered(vec![param_value.to_string()]);
                     true
@@ -1079,11 +1097,20 @@ impl RedisFdwState {
             RedisTableType::ZSet(ref mut t) => {
                 // param_column == 0 means lookup by member → ZSCORE
                 if self.param_column == 0 {
-                    let score: Option<f64> = redis::cmd("ZSCORE")
+                    let score: Option<f64> = match redis::cmd("ZSCORE")
                         .arg(&self.table_key_prefix)
                         .arg(param_value)
                         .query(conn)
-                        .unwrap_or(None);
+                    {
+                        Ok(v) => v,
+                        Err(e) => {
+                            pgrx::warning!(
+                                "redis_fdw: ZSCORE failed during parameterized lookup: {}",
+                                e
+                            );
+                            None
+                        }
+                    };
                     if let Some(s) = score {
                         t.dataset = DataSet::Complete(DataContainer::ZSet(vec![(
                             param_value.to_string(),
@@ -1098,10 +1125,16 @@ impl RedisFdwState {
             RedisTableType::String(ref mut t) => {
                 // Multi-key mode: param_column == 0 means lookup by key → GET
                 if self.is_multi_key && self.param_column == 0 {
-                    let val: Option<String> = redis::cmd("GET")
-                        .arg(param_value)
-                        .query(conn)
-                        .unwrap_or(None);
+                    let val: Option<String> = match redis::cmd("GET").arg(param_value).query(conn) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            pgrx::warning!(
+                                "redis_fdw: GET failed during parameterized lookup: {}",
+                                e
+                            );
+                            None
+                        }
+                    };
                     if let Some(v) = val {
                         t.dataset = DataSet::Filtered(vec![param_value.to_string(), v]);
                         return true;

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -11,9 +11,9 @@ use crate::{
         cost_estimation::{CostEstimate, CostEstimator},
         pushdown_types::{ComparisonOperator, PushdownAnalysis},
     },
-    tables::types::RedisTableType,
+    tables::types::{DataContainer, DataSet, RedisTableType},
 };
-use pgrx::{pg_sys::MemoryContext, prelude::*};
+use pgrx::{pg_sys, pg_sys::MemoryContext, prelude::*};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -55,6 +55,14 @@ pub struct RedisFdwState {
     pub join_executed: bool,
     /// Column names from the foreign table's tuple descriptor
     pub column_names: Vec<String>,
+    /// Whether this is a parameterized scan (receives join key from outer NestLoop)
+    pub is_parameterized: bool,
+    /// Column index (0-based, after TTL strip) that receives the parameter value
+    pub param_column: usize,
+    /// ExprState for evaluating the parameterized expression at runtime
+    pub param_expr_state: *mut pg_sys::ExprState,
+    /// PlanState pointer for expression evaluation context
+    pub param_plan_state: *mut pg_sys::PlanState,
 }
 
 impl RedisFdwState {
@@ -83,6 +91,10 @@ impl RedisFdwState {
             join_state: None,
             join_executed: false,
             column_names: Vec::new(),
+            is_parameterized: false,
+            param_column: 0,
+            param_expr_state: std::ptr::null_mut(),
+            param_plan_state: std::ptr::null_mut(),
         }
     }
 
@@ -1022,6 +1034,68 @@ impl RedisFdwState {
                 redis::ErrorKind::Io,
                 "Redis connection not initialized",
             )))
+        }
+    }
+
+    /// Execute a parameterized point-lookup for a single value.
+    /// Used during NestLoop joins to fetch only the matching row instead of full scan.
+    pub fn parameterized_lookup(&mut self, param_value: &str) -> bool {
+        let conn = match self.redis_connection.as_mut() {
+            Some(c) => c.as_connection_like_mut(),
+            None => return false,
+        };
+
+        match &mut self.table_type {
+            RedisTableType::Hash(ref mut t) => {
+                // param_column == 0 means lookup by field name → HGET
+                if self.param_column == 0 {
+                    let val: Option<String> = redis::cmd("HGET")
+                        .arg(&self.table_key_prefix)
+                        .arg(param_value)
+                        .query(conn)
+                        .unwrap_or(None);
+                    if let Some(v) = val {
+                        t.dataset = DataSet::Filtered(vec![param_value.to_string(), v]);
+                        return true;
+                    }
+                    t.dataset = DataSet::Empty;
+                }
+                false
+            }
+            RedisTableType::Set(ref mut t) => {
+                let exists: bool = redis::cmd("SISMEMBER")
+                    .arg(&self.table_key_prefix)
+                    .arg(param_value)
+                    .query(conn)
+                    .unwrap_or(false);
+                if exists {
+                    t.dataset = DataSet::Filtered(vec![param_value.to_string()]);
+                    true
+                } else {
+                    t.dataset = DataSet::Empty;
+                    false
+                }
+            }
+            RedisTableType::ZSet(ref mut t) => {
+                // param_column == 0 means lookup by member → ZSCORE
+                if self.param_column == 0 {
+                    let score: Option<f64> = redis::cmd("ZSCORE")
+                        .arg(&self.table_key_prefix)
+                        .arg(param_value)
+                        .query(conn)
+                        .unwrap_or(None);
+                    if let Some(s) = score {
+                        t.dataset = DataSet::Complete(DataContainer::ZSet(vec![(
+                            param_value.to_string(),
+                            s,
+                        )]));
+                        return true;
+                    }
+                    t.dataset = DataSet::Empty;
+                }
+                false
+            }
+            _ => false,
         }
     }
 }

--- a/src/core/truncate.rs
+++ b/src/core/truncate.rs
@@ -1,0 +1,90 @@
+use crate::{
+    core::connection_factory::{RedisConnectionConfig, RedisConnectionFactory},
+    core::state_manager::is_multi_key_pattern,
+    utils::helpers::get_foreign_table_options,
+};
+use pgrx::prelude::*;
+
+#[pg_guard]
+pub(crate) unsafe extern "C-unwind" fn exec_foreign_truncate(
+    rels: *mut pg_sys::List,
+    _behavior: pg_sys::DropBehavior::Type,
+    _restart_seqs: bool,
+) {
+    log!("---> exec_foreign_truncate");
+
+    if rels.is_null() {
+        return;
+    }
+
+    pgrx::memcx::current_context(|mcx| {
+        let rel_list = pgrx::list::List::<*mut std::ffi::c_void>::downcast_ptr_in_memcx(rels, mcx)
+            .expect("Failed to downcast rels list");
+
+        for rel_ptr in rel_list.iter() {
+            let relation = *rel_ptr as pg_sys::Relation;
+            if relation.is_null() {
+                continue;
+            }
+            let relid = (*relation).rd_id;
+            let options = get_foreign_table_options(relid);
+
+            let config = match RedisConnectionConfig::from_options(&options) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!("Failed to create Redis config for truncate: {}", e);
+                }
+            };
+
+            let mut conn = match RedisConnectionFactory::create_connection_with_retry(&config) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!("Failed to connect to Redis for truncate: {}", e);
+                }
+            };
+
+            let conn_like = conn.as_connection_like_mut();
+            let key_prefix = options.get("table_key_prefix").cloned().unwrap_or_default();
+
+            if is_multi_key_pattern(&key_prefix) {
+                let mut cursor: u64 = 0;
+                loop {
+                    pgrx::check_for_interrupts!();
+                    let (new_cursor, keys): (u64, Vec<String>) = match redis::cmd("SCAN")
+                        .arg(cursor)
+                        .arg("MATCH")
+                        .arg(&key_prefix)
+                        .arg("COUNT")
+                        .arg(1000u32)
+                        .query(conn_like)
+                    {
+                        Ok(r) => r,
+                        Err(e) => {
+                            error!("Redis SCAN error during truncate: {}", e);
+                        }
+                    };
+
+                    if !keys.is_empty() {
+                        let mut pipe = redis::pipe();
+                        for key in &keys {
+                            pipe.cmd("UNLINK").arg(key);
+                        }
+                        if let Err(e) = pipe.query::<Vec<redis::Value>>(conn_like) {
+                            error!("Redis UNLINK pipeline failed during truncate: {}", e);
+                        }
+                    }
+
+                    cursor = new_cursor;
+                    if cursor == 0 {
+                        break;
+                    }
+                }
+            } else if let Err(e) = redis::cmd("UNLINK")
+                .arg(&key_prefix)
+                .query::<i64>(conn_like)
+            {
+                error!("Redis UNLINK failed for key '{}': {}", key_prefix, e);
+            }
+        }
+    });
+}

--- a/src/tables/implementations/string.rs
+++ b/src/tables/implementations/string.rs
@@ -9,6 +9,7 @@ use crate::{
         types::{DataContainer, DataSet, LoadDataResult},
     },
 };
+use std::borrow::Cow;
 
 /// Redis String table type
 #[derive(Debug, Clone, Default)]
@@ -137,6 +138,34 @@ impl RedisTableOperations for RedisStringTable {
 
     fn get_dataset(&self) -> &DataSet {
         &self.dataset
+    }
+
+    /// Override get_row to handle multi-key filtered data format [key, value, key, value, ...]
+    #[inline]
+    fn get_row(&self, index: usize) -> Option<Vec<Cow<'_, str>>> {
+        match &self.dataset {
+            DataSet::Filtered(data) if data.len() >= 2 && data.len() % 2 == 0 => {
+                let data_index = index * 2;
+                if data_index + 1 < data.len() {
+                    Some(vec![
+                        Cow::Borrowed(data[data_index].as_str()),
+                        Cow::Borrowed(data[data_index + 1].as_str()),
+                    ])
+                } else {
+                    None
+                }
+            }
+            _ => self.dataset.get_row(index),
+        }
+    }
+
+    /// Override data_len to handle multi-key filtered data format
+    #[inline]
+    fn data_len(&self) -> usize {
+        match &self.dataset {
+            DataSet::Filtered(data) if data.len() >= 2 && data.len() % 2 == 0 => data.len() / 2,
+            _ => self.dataset.len(),
+        }
     }
 
     fn insert(

--- a/src/tests/column_validation_tests.rs
+++ b/src/tests/column_validation_tests.rs
@@ -1,0 +1,294 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    const REDIS_HOST_PORT: &str = "127.0.0.1:8899";
+    const TEST_DATABASE: &str = "15";
+    const FDW_NAME: &str = "redis_colval_fdw";
+    const SERVER_NAME: &str = "redis_colval_server";
+
+    fn setup_fdw() {
+        let _ = Spi::run(&format!(
+            "DROP FOREIGN DATA WRAPPER IF EXISTS {} CASCADE;",
+            FDW_NAME
+        ));
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {} HANDLER redis_fdw_handler VALIDATOR redis_fdw_validator;",
+            FDW_NAME
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "CREATE SERVER {} FOREIGN DATA WRAPPER {} OPTIONS (host_port '{}');",
+            SERVER_NAME, FDW_NAME, REDIS_HOST_PORT
+        ))
+        .unwrap();
+    }
+
+    fn cleanup_redis_key(key: &str) {
+        let mut conn = redis::Client::open("redis://127.0.0.1:8899/15")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let _: Result<(), _> = redis::cmd("DEL").arg(key).query(&mut conn);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // String type: exactly 1 data column
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[pg_test]
+    #[should_panic(expected = "redis_fdw: table type 'string' requires exactly 1 data column")]
+    fn test_string_rejects_too_many_columns() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_str_bad (value text, extra text) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix 'colval:str:bad'
+            );",
+            SERVER_NAME, TEST_DATABASE
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_str_bad;").unwrap();
+    }
+
+    #[pg_test]
+    fn test_string_accepts_one_column() {
+        setup_fdw();
+        let key = "colval:str:ok";
+        cleanup_redis_key(key);
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_str_ok (value text) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_str_ok;").unwrap();
+    }
+
+    #[pg_test]
+    fn test_string_with_ttl_is_valid() {
+        setup_fdw();
+        let key = "colval:str:ttl";
+        cleanup_redis_key(key);
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_str_ttl (value text, ttl bigint) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}', ttl '3600'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_str_ttl;").unwrap();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Hash type: exactly 2 data columns
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[pg_test]
+    #[should_panic(expected = "redis_fdw: table type 'hash' requires exactly 2 data column")]
+    fn test_hash_rejects_too_many_columns() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_hash_bad (field text, value text, extra1 text, extra2 text, extra3 text) SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix 'colval:hash:bad'
+            );",
+            SERVER_NAME, TEST_DATABASE
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_hash_bad;").unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "redis_fdw: table type 'hash' requires exactly 2 data column")]
+    fn test_hash_rejects_too_few_columns() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_hash_few (field text) SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix 'colval:hash:few'
+            );",
+            SERVER_NAME, TEST_DATABASE
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_hash_few;").unwrap();
+    }
+
+    #[pg_test]
+    fn test_hash_accepts_exactly_two_columns() {
+        setup_fdw();
+        let key = "colval:hash:ok";
+        cleanup_redis_key(key);
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_hash_ok (field text, value text) SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_hash_ok;").unwrap();
+    }
+
+    #[pg_test]
+    fn test_hash_with_ttl_is_valid() {
+        setup_fdw();
+        let key = "colval:hash:ttl";
+        cleanup_redis_key(key);
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_hash_ttl (field text, value text, ttl bigint) SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}', ttl '300'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_hash_ttl;").unwrap();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Set type: exactly 1 data column
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[pg_test]
+    #[should_panic(expected = "redis_fdw: table type 'set' requires exactly 1 data column")]
+    fn test_set_rejects_two_columns() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_set_bad (member text, extra text) SERVER {} OPTIONS (
+                database '{}', table_type 'set', table_key_prefix 'colval:set:bad'
+            );",
+            SERVER_NAME, TEST_DATABASE
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_set_bad;").unwrap();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ZSet type: exactly 2 data columns
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[pg_test]
+    #[should_panic(expected = "redis_fdw: table type 'zset' requires exactly 2 data column")]
+    fn test_zset_rejects_three_columns() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_zset_bad (member text, score float8, extra text) SERVER {} OPTIONS (
+                database '{}', table_type 'zset', table_key_prefix 'colval:zset:bad'
+            );",
+            SERVER_NAME, TEST_DATABASE
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_zset_bad;").unwrap();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // List type: 1 or 2 data columns
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[pg_test]
+    fn test_list_accepts_one_column() {
+        setup_fdw();
+        let key = "colval:list:one";
+        cleanup_redis_key(key);
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_list_one (element text) SERVER {} OPTIONS (
+                database '{}', table_type 'list', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_list_one;").unwrap();
+    }
+
+    #[pg_test]
+    fn test_list_accepts_two_columns() {
+        setup_fdw();
+        let key = "colval:list:two";
+        cleanup_redis_key(key);
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_list_two (idx int, element text) SERVER {} OPTIONS (
+                database '{}', table_type 'list', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_list_two;").unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "redis_fdw: table type 'list' requires 1-2 data column")]
+    fn test_list_rejects_three_columns() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_list_bad (idx int, element text, extra text) SERVER {} OPTIONS (
+                database '{}', table_type 'list', table_key_prefix 'colval:list:bad'
+            );",
+            SERVER_NAME, TEST_DATABASE
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_list_bad;").unwrap();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Stream type: 2+ columns (no max)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[pg_test]
+    fn test_stream_accepts_many_columns() {
+        setup_fdw();
+        let key = "colval:stream:many";
+        cleanup_redis_key(key);
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_stream_many (stream_id text, f1 text, f2 text, f3 text, f4 text) SERVER {} OPTIONS (
+                database '{}', table_type 'stream', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_stream_many;").unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "redis_fdw: table type 'stream' requires 2")]
+    fn test_stream_rejects_one_column() {
+        setup_fdw();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_stream_bad (stream_id text) SERVER {} OPTIONS (
+                database '{}', table_type 'stream', table_key_prefix 'colval:stream:bad'
+            );",
+            SERVER_NAME, TEST_DATABASE
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_stream_bad;").unwrap();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Multi-key mode: adds +1 for key column
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[pg_test]
+    fn test_multi_key_allows_extra_key_column() {
+        setup_fdw();
+        let key = "colval:multi:*";
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_multi_ok (key text, value text) SERVER {} OPTIONS (
+                database '{}', table_type 'string', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_multi_ok;").unwrap();
+    }
+
+    #[pg_test]
+    fn test_multi_key_hash_three_columns() {
+        setup_fdw();
+        let key = "colval:multih:*";
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE colval_multih_ok (key text, field text, value text) SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}'
+            );",
+            SERVER_NAME, TEST_DATABASE, key
+        ))
+        .unwrap();
+        Spi::run("SELECT * FROM colval_multih_ok;").unwrap();
+    }
+}

--- a/src/tests/column_validation_tests.rs
+++ b/src/tests/column_validation_tests.rs
@@ -247,7 +247,7 @@ mod tests {
     }
 
     #[pg_test]
-    #[should_panic(expected = "redis_fdw: table type 'stream' requires 2")]
+    #[should_panic(expected = "redis_fdw: table type 'stream' requires at least 2")]
     fn test_stream_rejects_one_column() {
         setup_fdw();
         Spi::run(&format!(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -67,3 +67,6 @@ pub mod join_tests;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub mod column_mapping_tests;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod column_validation_tests;


### PR DESCRIPTION
- Add schema import functionality for Redis foreign tables, allowing users to import schemas based on Redis keys and types.
- Implement foreign truncate functionality to delete keys in Redis corresponding to foreign tables.
- Introduce comprehensive column validation tests for various Redis data types (string, hash, set, zset, list, stream) to ensure correct column configurations.
- Validate multi-key patterns and ensure proper handling of key prefixes in foreign table definitions.