### PR TITLE
Enhance ZSet support with score-range pushdown using ZRANGEBYSCORE and add related tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 **Feature-complete for all CRUD operations plus EXPLAIN, batch INSERT, TRUNCATE, IMPORT FOREIGN SCHEMA, ANALYZE, and COPY FROM.** All Redis types (String, Hash, List, Set, ZSet) support SELECT, INSERT, UPDATE, DELETE, TRUNCATE. Stream supports SELECT, INSERT, DELETE, TRUNCATE only (append-only by design).
 
 ### Recent Work
+- TTL-position-aware modify path: `add_foreign_update_targets` now skips TTL column at position 0, fixing DELETE/UPDATE crashes on TTL-first tables
+- TTL-aware parameterized JOIN paths: `add_parameterized_paths` uses `compute_pushdown_column_index()` instead of hardcoded column 0
+- TTL-aware FDW-to-FDW join columns: `get_foreign_join_paths` adjusts join column indices for TTL stripping via `adjust_column_for_ttl_strip()`
+- Single-key String join guard: FDW-to-FDW pushdown correctly rejects single-key String tables (no join column to match)
+- ZSet score-range pushdown: `WHERE score >= X` / `score <= Y` uses ZRANGEBYSCORE instead of full ZSCAN (O(log N + M) vs O(N))
 - DDL-time column validation: `object_access_hook` in `ddl_hook.rs` validates column count at `CREATE FOREIGN TABLE` time (no longer deferred to first query)
 - Position-based column filtering: `PushableCondition.column_index` replaces hardcoded column name checks in hash/zset pushdown
 - Column validation: `validate_column_count()` enforces per-type column constraints at first query time (string=1, hash=2, list=1-2, set=1, zset=2, stream=2+)
@@ -39,7 +44,7 @@ A **PostgreSQL Foreign Data Wrapper** that maps Redis data structures to SQL tab
 
 ### Known Issues
 - Cluster integration tests (9 tests) fail without Redis Cluster infrastructure running
-- All non-cluster tests pass (including 23 JOIN tests, 16 column validation tests, and 4 pool performance tests)
+- All non-cluster tests pass (including 28 JOIN tests, 16 column validation tests, and 4 pool performance tests)
 
 ## How to Work on This Project
 
@@ -90,14 +95,18 @@ JOIN tests create temporary local tables + Redis foreign tables and verify:
 - List type JOINs and String multi-key JOINs
 - Large dataset JOINs (100+ rows)
 - Rescan correctness (duplicate local rows trigger multiple scans)
+- TTL column at position 0 (before data columns) for hash, zset, set JOINs
+- TTL column at middle position (between data columns) for hash JOINs
+- FDW-to-FDW hash join with TTL at position 0 on both sides
 
 **Join pushdown eligibility requires ALL of:**
 1. Both tables on same Redis server (host_port match)
 2. Neither table in multi-key pattern mode (no glob in table_key_prefix)
 3. Neither table is a Stream type (variable-width rows not supported)
-4. Equality operator in join condition (`op_mergejoinable()` check)
-5. INNER JOIN or LEFT JOIN only (RIGHT/FULL not pushed down)
-6. Neither relation has base WHERE restrictions (`baserestrictinfo` must be empty)
+4. Neither table is a single-key String type (only one value, no join column)
+5. Equality operator in join condition (`op_mergejoinable()` check)
+6. INNER JOIN or LEFT JOIN only (RIGHT/FULL not pushed down)
+7. Neither relation has base WHERE restrictions (`baserestrictinfo` must be empty)
 
 ### Adding a New Feature
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,12 +48,14 @@ cargo fmt
 ### FDW Lifecycle (PostgreSQL callbacks)
 1. **Planning**: `get_foreign_rel_size` → `get_foreign_paths` → `get_foreign_plan`
    - Planning (`get_foreign_rel_size`) connects to Redis for real statistics (DBSIZE, HLEN, etc.)
+   - Planning detects TTL column early so `get_foreign_paths` can compute correct pushdown column indices for parameterized paths
    - Planning releases connection immediately; `begin_foreign_scan` re-acquires from pool (fast path: read-lock only)
 2. **Scanning**: `begin_foreign_scan` → `iterate_foreign_scan` → `re_scan_foreign_scan` → `end_foreign_scan`
    - `recheck_foreign_scan` (returns true; no lossy filtering)
    - `shutdown_foreign_scan` (early connection release back to pool)
 3. **Explain**: `explain_foreign_scan`, `explain_foreign_modify` (EXPLAIN output with server, key, type, pushdown, batch info)
 4. **Modify**: `plan_foreign_modify` → `begin_foreign_modify` → `exec_foreign_insert`/`update`/`delete` → `end_foreign_modify`
+   - `add_foreign_update_targets` registers the row identity column (first non-TTL column) for UPDATE/DELETE operations; skips TTL column at position 0
 5. **Batch Insert**: `get_foreign_modify_batch_size` → `exec_foreign_batch_insert` (pipelined multi-row)
 6. **COPY FROM / INSERT SELECT**: `begin_foreign_insert` → (reuses `exec_foreign_insert`) → `end_foreign_insert`
 7. **Truncate**: `exec_foreign_truncate` (UNLINK for single-key; SCAN+UNLINK for patterns)
@@ -113,15 +115,16 @@ Stream is append-only; UPDATE returns an error at the trait level and `IsForeign
 ### WHERE Pushdown
 - `PushableCondition` carries `column_index: usize` (0-based, from `varattno - 1`) — this is the raw PostgreSQL attribute position
 - Hash/ZSet/Stream table types store a `pushdown_column_index: usize` field that identifies the target column for pushdown (field for hash, member for zset, stream_id for stream)
+- ZSet additionally stores `score_column_index: usize` = `pushdown_column_index + 1`; range operators (>=, <=, >, <) on the score column trigger ZRANGEBYSCORE instead of ZSCAN
 - `pushdown_column_index` is computed by `compute_pushdown_column_index(ttl_column_index, is_multi_key)` in `column_utils.rs`, accounting for TTL column position and multi-key offset
 - Filtering compares `condition.column_index == self.pushdown_column_index` (not hardcoded to 0)
 - Column names are user-chosen — filtering is position-based, never hardcoded to specific names
 
 ### JOIN Architecture
-- **FDW-to-Local (parameterized)**: `get_foreign_paths` advertises cheap parameterized paths for point-lookup columns (hash/field→HGET, set/member→SISMEMBER, zset/member→ZSCORE). PostgreSQL's planner picks these for NestLoop joins, passing the outer row's value as a parameter. `iterate_foreign_scan` evaluates the expression and does a single-key Redis lookup per outer row.
+- **FDW-to-Local (parameterized)**: `get_foreign_paths` advertises cheap parameterized paths for point-lookup columns (hash/field→HGET, set/member→SISMEMBER, zset/member→ZSCORE). Uses EquivalenceClass (EC) detection from `root->eq_classes` and `compute_pushdown_column_index()` to find the correct column even when TTL column is at position 0. Costs tuned low (`PARAMETERIZED_LOOKUP_COST=0.5`) so the planner auto-selects parameterized path when the outer side is small (typically 50×+ faster than full scan for selective joins).
 - **FDW-to-Local (fallback)**: If no parameterized path applies, standard nested-loop with full rescan on each iteration
-- **FDW-to-FDW**: `GetForeignJoinPaths` detects same-server tables, extracts join columns from restrictlist, creates pushdown join path
-- **Pushdown guards**: same server (host_port match), non-multi-key tables, non-Stream tables, merge-joinable (equality) operator, INNER/LEFT only, no base restrictions on either relation
+- **FDW-to-FDW**: `GetForeignJoinPaths` detects same-server tables, extracts join columns from restrictlist, adjusts for TTL column stripping via `adjust_column_for_ttl_strip()`, creates pushdown join path
+- **Pushdown guards**: same server (host_port match), non-multi-key tables, non-Stream tables, non-single-key-String tables, merge-joinable (equality) operator, INNER/LEFT only, no base restrictions on either relation
 - **Base restriction guard**: If either relation has `baserestrictinfo` (WHERE clauses on individual tables), pushdown is skipped and PostgreSQL falls back to nested-loop which handles base quals correctly
 - **Join column detection**: Walks `extra.restrictlist` → `RestrictInfo` → `OpExpr` → validates `op_mergejoinable()` → `Var` nodes to find equality columns
 - **Join execution**: Fetch both datasets → build HashMap on smaller side → probe with larger side → LEFT JOIN NULL-pads unmatched outer rows

--- a/README.md
+++ b/README.md
@@ -272,10 +272,15 @@ CREATE FOREIGN TABLE cached_data (value text)
 SERVER redis_server
 OPTIONS (table_type 'string', table_key_prefix 'cache:item1', ttl '3600');
 
--- Per-row TTL override via virtual column
+-- Per-row TTL override via virtual column (TTL column can be at any position)
 CREATE FOREIGN TABLE cached_items (value text, ttl bigint)
 SERVER redis_server
 OPTIONS (table_type 'string', table_key_prefix 'cache:item2', ttl '3600');
+
+-- TTL column at first position is also supported
+CREATE FOREIGN TABLE cached_hash (ttl bigint, field text, value text)
+SERVER redis_server
+OPTIONS (table_type 'hash', table_key_prefix 'cache:hash1', ttl '3600');
 
 INSERT INTO cached_items VALUES ('short-lived', 60);   -- expires in 60s
 UPDATE cached_items SET value = 'permanent', ttl = -1; -- persist forever
@@ -383,6 +388,10 @@ SELECT * FROM user_profiles WHERE field IN ('name', 'email', 'phone');
 
 -- Set: uses SISMEMBER for direct membership check
 SELECT EXISTS(SELECT 1 FROM user_roles WHERE member = 'admin');
+
+-- ZSet: uses ZRANGEBYSCORE for score range queries (O(log N + M) instead of full scan)
+SELECT * FROM leaderboard WHERE score >= 1000 AND score <= 2000;
+SELECT * FROM leaderboard WHERE score > 99000 ORDER BY score DESC;
 ```
 
 ### Bulk Insert Example
@@ -487,6 +496,7 @@ The FDW automatically detects which columns are used in the join condition from 
 - Neither table can have base WHERE restrictions (these force nested-loop fallback)
 - Multi-key pattern tables (glob in `table_key_prefix`) cannot be push-down joined
 - Stream tables are not eligible for join pushdown (variable-width rows)
+- Single-key String tables are not eligible for join pushdown (no join column)
 - RIGHT JOIN and FULL OUTER JOIN are not pushed down (handled via nested-loop)
 - Both datasets are loaded into memory for the hash join (warning emitted if >500K rows)
 - Redis command errors during join fetch are raised as SQL errors (no silent data loss)

--- a/examples/00_setup.sql
+++ b/examples/00_setup.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- Redis FDW RS - Setup
+-- ============================================================
+-- Prerequisites:
+--   make setup-redis   (starts Redis on 127.0.0.1:8899)
+--   cargo pgrx install --release
+--   cargo pgrx run
+-- ============================================================
+
+-- 1. Create the extension
+CREATE EXTENSION IF NOT EXISTS redis_fdw_rs;
+
+-- 2. Create the Foreign Data Wrapper
+CREATE FOREIGN DATA WRAPPER redis_wrapper
+    HANDLER redis_fdw_handler
+    VALIDATOR redis_fdw_validator;
+
+-- 3. Create the server connection (points to local Redis container)
+CREATE SERVER redis_server
+    FOREIGN DATA WRAPPER redis_wrapper
+    OPTIONS (host_port '127.0.0.1:8899');
+
+-- Verify setup
+SELECT * FROM pg_foreign_server WHERE srvname = 'redis_server';

--- a/examples/01_string_type.sql
+++ b/examples/01_string_type.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- Demo 1: String Type - Simple Key-Value Storage
+-- ============================================================
+-- Redis String is the most basic type: one key → one value
+-- Mapped to a single-column foreign table
+-- ============================================================
+
+-- Create a foreign table backed by a Redis STRING key
+CREATE FOREIGN TABLE demo_config (value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'string',
+        table_key_prefix 'app:config:version'
+    );
+
+-- INSERT sets the Redis key
+INSERT INTO demo_config VALUES ('2.1.0');
+
+-- SELECT reads the key
+SELECT * FROM demo_config;
+
+-- UPDATE modifies the value
+UPDATE demo_config SET value = '2.2.0';
+SELECT * FROM demo_config;
+
+-- DELETE removes the key from Redis
+DELETE FROM demo_config;
+SELECT * FROM demo_config;  -- returns empty
+
+-- Cleanup
+DROP FOREIGN TABLE demo_config;

--- a/examples/02_hash_type.sql
+++ b/examples/02_hash_type.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- Demo 2: Hash Type - Structured Records
+-- ============================================================
+-- Redis Hash maps to (field, value) pairs
+-- Perfect for storing structured objects
+-- ============================================================
+
+-- Create a foreign table backed by a Redis HASH
+CREATE FOREIGN TABLE demo_user_profile (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'user:1001'
+    );
+
+-- INSERT adds fields to the hash
+INSERT INTO demo_user_profile VALUES ('name', 'Alice Chen');
+INSERT INTO demo_user_profile VALUES ('email', 'alice@example.com');
+INSERT INTO demo_user_profile VALUES ('role', 'engineer');
+INSERT INTO demo_user_profile VALUES ('team', 'platform');
+
+-- SELECT reads all hash fields
+SELECT * FROM demo_user_profile;
+
+-- WHERE clause pushdown: uses HGET instead of HGETALL + filter
+-- (Check with EXPLAIN to see pushdown in action)
+EXPLAIN (VERBOSE) SELECT value FROM demo_user_profile WHERE field = 'email';
+SELECT value FROM demo_user_profile WHERE field = 'email';
+
+-- UPDATE a specific field
+UPDATE demo_user_profile SET value = 'senior engineer' WHERE field = 'role';
+SELECT * FROM demo_user_profile;
+
+-- DELETE a specific field
+DELETE FROM demo_user_profile WHERE field = 'team';
+SELECT * FROM demo_user_profile;
+
+-- Cleanup
+DROP FOREIGN TABLE demo_user_profile;

--- a/examples/03_list_type.sql
+++ b/examples/03_list_type.sql
@@ -1,0 +1,35 @@
+-- ============================================================
+-- Demo 3: List Type - Ordered Collections
+-- ============================================================
+-- Redis List: ordered sequence with index-based access
+-- Mapped to (index, value) columns
+-- ============================================================
+
+-- Create a foreign table backed by a Redis LIST
+CREATE FOREIGN TABLE demo_task_queue (index int, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'list',
+        table_key_prefix 'queue:tasks'
+    );
+
+-- INSERT appends elements to the list
+INSERT INTO demo_task_queue (value) VALUES ('deploy-service-a');
+INSERT INTO demo_task_queue (value) VALUES ('run-migrations');
+INSERT INTO demo_task_queue (value) VALUES ('notify-slack');
+INSERT INTO demo_task_queue (value) VALUES ('update-dashboard');
+
+-- SELECT shows all elements with their indices
+SELECT * FROM demo_task_queue;
+
+-- Use LIMIT/OFFSET for pagination
+SELECT * FROM demo_task_queue LIMIT 2;
+SELECT * FROM demo_task_queue LIMIT 2 OFFSET 2;
+
+-- DELETE by value
+DELETE FROM demo_task_queue WHERE value = 'run-migrations';
+SELECT * FROM demo_task_queue;
+
+-- Cleanup
+DROP FOREIGN TABLE demo_task_queue;

--- a/examples/04_set_type.sql
+++ b/examples/04_set_type.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- Demo 4: Set Type - Unique Collections
+-- ============================================================
+-- Redis Set: unordered collection of unique strings
+-- Great for tags, memberships, unique tracking
+-- ============================================================
+
+-- Create a foreign table backed by a Redis SET
+CREATE FOREIGN TABLE demo_user_tags (member text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'set',
+        table_key_prefix 'user:1001:tags'
+    );
+
+-- INSERT adds members (duplicates are ignored by Redis)
+INSERT INTO demo_user_tags VALUES ('rust');
+INSERT INTO demo_user_tags VALUES ('postgresql');
+INSERT INTO demo_user_tags VALUES ('redis');
+INSERT INTO demo_user_tags VALUES ('linux');
+INSERT INTO demo_user_tags VALUES ('rust');  -- duplicate, will be ignored
+
+-- SELECT all members
+SELECT * FROM demo_user_tags;
+
+-- WHERE clause pushdown: uses SISMEMBER for existence check
+EXPLAIN (VERBOSE) SELECT * FROM demo_user_tags WHERE member = 'rust';
+SELECT * FROM demo_user_tags WHERE member = 'rust';
+
+-- DELETE a specific member
+DELETE FROM demo_user_tags WHERE member = 'linux';
+SELECT * FROM demo_user_tags;
+
+-- Cleanup
+DROP FOREIGN TABLE demo_user_tags;

--- a/examples/05_zset_type.sql
+++ b/examples/05_zset_type.sql
@@ -1,0 +1,42 @@
+-- ============================================================
+-- Demo 5: Sorted Set (ZSet) - Scored Rankings
+-- ============================================================
+-- Redis Sorted Set: members with floating-point scores
+-- Perfect for leaderboards, priority queues, time-series indexes
+-- ============================================================
+
+-- Create a foreign table backed by a Redis ZSET
+CREATE FOREIGN TABLE demo_leaderboard (member text, score numeric)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'zset',
+        table_key_prefix 'game:leaderboard'
+    );
+
+-- INSERT adds scored members
+INSERT INTO demo_leaderboard VALUES ('alice', 2500);
+INSERT INTO demo_leaderboard VALUES ('bob', 1800);
+INSERT INTO demo_leaderboard VALUES ('charlie', 3200);
+INSERT INTO demo_leaderboard VALUES ('diana', 2900);
+INSERT INTO demo_leaderboard VALUES ('eve', 1500);
+
+-- SELECT returns members sorted by score (ascending)
+SELECT * FROM demo_leaderboard;
+
+-- ORDER BY and LIMIT work for top-N queries
+SELECT * FROM demo_leaderboard ORDER BY score DESC LIMIT 3;
+
+-- WHERE pushdown: score range queries
+SELECT * FROM demo_leaderboard WHERE score >= 2000;
+
+-- UPDATE a member's score
+UPDATE demo_leaderboard SET score = 3500 WHERE member = 'alice';
+SELECT * FROM demo_leaderboard ORDER BY score DESC;
+
+-- DELETE a member
+DELETE FROM demo_leaderboard WHERE member = 'eve';
+SELECT * FROM demo_leaderboard;
+
+-- Cleanup
+DROP FOREIGN TABLE demo_leaderboard;

--- a/examples/06_stream_type.sql
+++ b/examples/06_stream_type.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- Demo 6: Stream Type - Append-Only Event Log
+-- ============================================================
+-- Redis Stream: append-only log with auto-generated IDs
+-- Perfect for event sourcing, audit logs, message queues
+-- Note: Streams are INSERT-only (no UPDATE)
+-- ============================================================
+
+-- Create a foreign table backed by a Redis STREAM
+CREATE FOREIGN TABLE demo_audit_log (stream_id text, user_id text, action text, resource text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'stream',
+        table_key_prefix 'audit:events'
+    );
+
+-- INSERT appends events (id='*' for auto-generated timestamp ID)
+INSERT INTO demo_audit_log VALUES ('*', 'user:alice', 'CREATE', 'project:alpha');
+INSERT INTO demo_audit_log VALUES ('*', 'user:bob', 'UPDATE', 'project:alpha');
+INSERT INTO demo_audit_log VALUES ('*', 'user:alice', 'DELETE', 'file:readme.md');
+INSERT INTO demo_audit_log VALUES ('*', 'user:charlie', 'CREATE', 'project:beta');
+
+-- SELECT reads the stream
+SELECT * FROM demo_audit_log;
+
+-- Filter by field values
+SELECT * FROM demo_audit_log WHERE user_id = 'user:alice';
+SELECT * FROM demo_audit_log WHERE action = 'CREATE';
+
+-- Cleanup
+DROP FOREIGN TABLE demo_audit_log;

--- a/examples/07_multi_key_pattern.sql
+++ b/examples/07_multi_key_pattern.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- Demo 7: Multi-Key Pattern Mode
+-- ============================================================
+-- When table_key_prefix contains a glob pattern (*, ?, []),
+-- the FDW scans multiple Redis keys as rows.
+-- First column = Redis key name, remaining columns = value data
+-- ============================================================
+
+-- First, seed some Redis keys using a helper table
+CREATE FOREIGN TABLE demo_session_seed (value text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'session:user101');
+INSERT INTO demo_session_seed VALUES ('{"logged_in": true, "ip": "10.0.0.1"}');
+DROP FOREIGN TABLE demo_session_seed;
+
+CREATE FOREIGN TABLE demo_session_seed2 (value text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'session:user102');
+INSERT INTO demo_session_seed2 VALUES ('{"logged_in": true, "ip": "10.0.0.2"}');
+DROP FOREIGN TABLE demo_session_seed2;
+
+CREATE FOREIGN TABLE demo_session_seed3 (value text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'session:user103');
+INSERT INTO demo_session_seed3 VALUES ('{"logged_in": false, "ip": "10.0.0.3"}');
+DROP FOREIGN TABLE demo_session_seed3;
+
+-- Now create a multi-key pattern table (note the * in the prefix)
+CREATE FOREIGN TABLE demo_sessions (key text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'string',
+        table_key_prefix 'session:*'
+    );
+
+-- SELECT scans all keys matching the pattern
+SELECT * FROM demo_sessions;
+
+-- Use PostgreSQL filtering on the results
+SELECT key, value FROM demo_sessions WHERE key LIKE '%user101%';
+
+-- INSERT into a specific key (first column = key name)
+INSERT INTO demo_sessions VALUES ('session:user104', '{"logged_in": true, "ip": "10.0.0.4"}');
+SELECT * FROM demo_sessions;
+
+-- DELETE a specific key
+DELETE FROM demo_sessions WHERE key = 'session:user104';
+SELECT * FROM demo_sessions;
+
+-- Cleanup
+DROP FOREIGN TABLE demo_sessions;

--- a/examples/08_ttl_support.sql
+++ b/examples/08_ttl_support.sql
@@ -1,0 +1,60 @@
+-- ============================================================
+-- Demo 8: TTL (Time-To-Live) Support
+-- ============================================================
+-- Redis keys can have automatic expiration.
+-- The FDW supports TTL via:
+--   1. Table-level default (ttl option)
+--   2. Per-row override (ttl column)
+-- ============================================================
+
+-- Table with a default TTL of 300 seconds (5 minutes)
+CREATE FOREIGN TABLE demo_cache (value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'string',
+        table_key_prefix 'cache:page:home',
+        ttl '300'
+    );
+
+INSERT INTO demo_cache VALUES ('<html>cached homepage</html>');
+SELECT * FROM demo_cache;
+
+-- Check TTL from Redis side (use psql's \! or redis-cli):
+-- redis-cli -p 8899 TTL cache:page:home
+-- Should show ~300
+
+DROP FOREIGN TABLE demo_cache;
+
+-- ============================================================
+-- Per-row TTL override using a ttl column
+-- ============================================================
+
+CREATE FOREIGN TABLE demo_cache_ttl (value text, ttl bigint)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'string',
+        table_key_prefix 'cache:api:response'
+    );
+
+-- Insert with custom TTL (60 seconds)
+INSERT INTO demo_cache_ttl VALUES ('{"data": "fresh"}', 60);
+SELECT * FROM demo_cache_ttl;
+-- The ttl column shows remaining seconds
+
+-- Insert with no expiry (ttl = -1 means persist forever)
+-- First change key for a new entry
+DROP FOREIGN TABLE demo_cache_ttl;
+CREATE FOREIGN TABLE demo_cache_persist (value text, ttl bigint)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'string',
+        table_key_prefix 'cache:api:permanent'
+    );
+INSERT INTO demo_cache_persist VALUES ('{"data": "permanent"}', -1);
+SELECT * FROM demo_cache_persist;
+
+-- Cleanup
+DROP FOREIGN TABLE demo_cache_persist;

--- a/examples/09_pushdown_optimization.sql
+++ b/examples/09_pushdown_optimization.sql
@@ -1,0 +1,64 @@
+-- ============================================================
+-- Demo 9: WHERE Clause Pushdown Optimization
+-- ============================================================
+-- The FDW pushes WHERE conditions to Redis when possible:
+--   Hash:  field = 'x'  → HGET (instead of HGETALL)
+--   Set:   member = 'x' → SISMEMBER (instead of SMEMBERS)
+--   ZSet:  score >= N   → ZRANGEBYSCORE
+--   List:  index = N    → LINDEX
+-- This dramatically reduces data transfer for selective queries.
+-- ============================================================
+
+\timing on
+
+-- Setup: Hash table with many fields
+CREATE FOREIGN TABLE demo_product (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'product:sku:12345'
+    );
+
+INSERT INTO demo_product VALUES ('name', 'Mechanical Keyboard');
+INSERT INTO demo_product VALUES ('price', '129.99');
+INSERT INTO demo_product VALUES ('brand', 'KeyCraft');
+INSERT INTO demo_product VALUES ('stock', '42');
+INSERT INTO demo_product VALUES ('category', 'electronics');
+INSERT INTO demo_product VALUES ('weight_kg', '0.85');
+
+-- Without pushdown: fetches ALL fields, filters in PG
+EXPLAIN (VERBOSE) SELECT * FROM demo_product;
+
+-- With pushdown: fetches ONLY the requested field via HGET
+EXPLAIN (VERBOSE) SELECT value FROM demo_product WHERE field = 'price';
+SELECT value FROM demo_product WHERE field = 'price';
+
+-- IN operator pushdown: uses HMGET for multiple fields
+EXPLAIN (VERBOSE) SELECT * FROM demo_product WHERE field IN ('name', 'price', 'stock');
+SELECT * FROM demo_product WHERE field IN ('name', 'price', 'stock');
+
+-- ============================================================
+-- ZSet score range pushdown
+-- ============================================================
+CREATE FOREIGN TABLE demo_scores (member text, score numeric)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'zset',
+        table_key_prefix 'demo:scores:range'
+    );
+
+INSERT INTO demo_scores VALUES ('a', 10);
+INSERT INTO demo_scores VALUES ('b', 20);
+INSERT INTO demo_scores VALUES ('c', 30);
+INSERT INTO demo_scores VALUES ('d', 40);
+INSERT INTO demo_scores VALUES ('e', 50);
+
+-- Range query pushed to ZRANGEBYSCORE
+EXPLAIN (VERBOSE) SELECT * FROM demo_scores WHERE score >= 25 AND score <= 45;
+SELECT * FROM demo_scores WHERE score >= 25 AND score <= 45;
+
+-- Cleanup
+DROP FOREIGN TABLE demo_product;
+DROP FOREIGN TABLE demo_scores;

--- a/examples/10_update_operations.sql
+++ b/examples/10_update_operations.sql
@@ -1,0 +1,87 @@
+-- ============================================================
+-- Demo 10: UPDATE Operations
+-- ============================================================
+-- The FDW maps UPDATE to the appropriate Redis command:
+--   String: SET (full value replace)
+--   Hash:   HSET field (single-field update)
+--   ZSet:   ZADD member score (score update)
+-- This file focuses on what UPDATE does, with EXPLAIN to show
+-- pushdown behavior.
+-- ============================================================
+
+\timing on
+
+-- ------------------------------------------------------------
+-- Part A: UPDATE on STRING (full-value replace via SET)
+-- ------------------------------------------------------------
+CREATE FOREIGN TABLE demo_upd_string (value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'string',
+        table_key_prefix 'upd:config:version'
+    );
+
+INSERT INTO demo_upd_string VALUES ('1.0.0');
+SELECT * FROM demo_upd_string;
+
+EXPLAIN (VERBOSE) UPDATE demo_upd_string SET value = '2.0.0';
+UPDATE demo_upd_string SET value = '2.0.0';
+SELECT * FROM demo_upd_string;
+
+-- ------------------------------------------------------------
+-- Part B: UPDATE on HASH (single field via HSET)
+-- ------------------------------------------------------------
+CREATE FOREIGN TABLE demo_upd_hash (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'upd:user:profile'
+    );
+
+INSERT INTO demo_upd_hash VALUES
+    ('name', 'Alice'),
+    ('role', 'engineer'),
+    ('city', 'Taipei');
+
+SELECT * FROM demo_upd_hash;
+
+-- Update one field — pushdown uses HSET (not HGETALL + rewrite)
+EXPLAIN (VERBOSE) UPDATE demo_upd_hash SET value = 'staff engineer' WHERE field = 'role';
+UPDATE demo_upd_hash SET value = 'staff engineer' WHERE field = 'role';
+SELECT * FROM demo_upd_hash;
+
+-- UPDATE without WHERE: every field gets the same value (rarely useful)
+UPDATE demo_upd_hash SET value = 'redacted' WHERE field IN ('name', 'city');
+SELECT * FROM demo_upd_hash;
+
+-- ------------------------------------------------------------
+-- Part C: UPDATE on ZSET (score change via ZADD)
+-- ------------------------------------------------------------
+CREATE FOREIGN TABLE demo_upd_zset (member text, score numeric)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'zset',
+        table_key_prefix 'upd:game:leaderboard'
+    );
+
+INSERT INTO demo_upd_zset VALUES
+    ('alice', 1000),
+    ('bob', 1500),
+    ('charlie', 800);
+
+SELECT * FROM demo_upd_zset ORDER BY score DESC;
+
+-- Bump alice's score
+EXPLAIN (VERBOSE) UPDATE demo_upd_zset SET score = score + 500 WHERE member = 'alice';
+UPDATE demo_upd_zset SET score = 1500 WHERE member = 'alice';
+SELECT * FROM demo_upd_zset ORDER BY score DESC;
+
+-- ------------------------------------------------------------
+-- Cleanup
+-- ------------------------------------------------------------
+DROP FOREIGN TABLE demo_upd_string;
+DROP FOREIGN TABLE demo_upd_hash;
+DROP FOREIGN TABLE demo_upd_zset;

--- a/examples/11_bulk_insert_and_large_join.sql
+++ b/examples/11_bulk_insert_and_large_join.sql
@@ -1,0 +1,210 @@
+-- ============================================================
+-- Demo 11: Bulk Insert (100K) + Pushdown-Driven Large JOIN
+-- ============================================================
+-- The headliner perf demo. Two features, one dataset:
+--
+--   Part 1: Bulk-load 100K rows (batch_size A/B test).
+--   Part 2: Pushdown JOIN — normal PG table ↔ Redis FDW.
+--             Shows the default full-scan plan vs the
+--             parameterized nested-loop plan that pushes
+--             one HGET per outer row.
+--   Part 3: Pushdown JOIN — Redis FDW ↔ Redis FDW.
+--             SET membership + HASH lookup, both pushed.
+--   Part 4: Bonus — ZSet score-range pushdown at scale.
+--
+-- The trick: PG only pushes "field = $1" when the planner picks
+-- a Nested Loop with a parameterized inner-side Foreign Scan.
+-- We turn off hash/merge join briefly to force that shape so the
+-- pushdown is visible on EXPLAIN.
+-- ============================================================
+
+\timing on
+\set ROWS 100000
+
+-- ============================================================
+-- PART 1: BULK INSERT 100K rows (batch_size A/B)
+-- ============================================================
+
+-- 1A. Baseline - small batch_size (more round-trips, slower)
+CREATE FOREIGN TABLE bulk_user_profiles_slow (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'demo11:users:slow',
+        batch_size '500'
+    );
+
+INSERT INTO bulk_user_profiles_slow
+SELECT
+    'user:' || g::text,
+    '{"name":"u_' || g::text || '","score":' || (random() * 1000)::int::text || '}'
+FROM generate_series(1, :ROWS) g;
+
+SELECT COUNT(*) AS loaded_slow FROM bulk_user_profiles_slow;
+
+-- 1B. Tuned - large batch_size (fewer round-trips, faster)
+--     This is the table the JOIN demos run against.
+CREATE FOREIGN TABLE bulk_user_profiles (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'demo11:users:profiles',
+        batch_size '10000'
+    );
+
+INSERT INTO bulk_user_profiles
+SELECT
+    'user:' || g::text,
+    '{"name":"u_' || g::text || '","score":' || (random() * 1000)::int::text || '}'
+FROM generate_series(1, :ROWS) g;
+
+SELECT COUNT(*) AS loaded_fast FROM bulk_user_profiles;
+
+-- Companion: active users (Redis SET, 50K subset)
+CREATE FOREIGN TABLE bulk_active_users (member text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'set',
+        table_key_prefix 'demo11:users:active',
+        batch_size '10000'
+    );
+
+INSERT INTO bulk_active_users
+SELECT 'user:' || g::text
+FROM generate_series(1, 50000) g;
+
+SELECT COUNT(*) AS active_users FROM bulk_active_users;
+
+-- ============================================================
+-- PART 2: Pushdown JOIN — local PG table × Redis FDW
+-- ============================================================
+-- Strategy: small local driver table (200 rows). When the planner
+-- picks a Nested Loop, the FDW gets `field = $1` per outer row
+-- and turns each into a single HGET — instead of one HGETALL
+-- fetching all 100K rows.
+
+-- A small "VIP" list — 200 specific users we want to enrich
+CREATE TEMPORARY TABLE vip_users (user_id text PRIMARY KEY);
+INSERT INTO vip_users
+SELECT 'user:' || g::text
+FROM generate_series(1, 200) g;
+
+-- ---- 2A. Default plan (planner picks Hash Join → full FDW scan) ----
+-- Foreign Scan returns all 100K rows via HGETALL.
+EXPLAIN (ANALYZE, VERBOSE)
+SELECT v.user_id, p.value AS profile
+FROM vip_users v
+JOIN bulk_user_profiles p ON v.user_id = p.field;
+
+-- ---- 2B. Force pushdown plan via Nested Loop ----
+-- Disable hash/merge join so PG picks Nested Loop with
+-- parameterized Foreign Scan. EXPLAIN should now show:
+--   Foreign Scan on bulk_user_profiles
+--     Filter: (field = v.user_id)      ← pushed to HGET
+SET LOCAL enable_hashjoin = off;
+SET LOCAL enable_mergejoin = off;
+
+EXPLAIN (ANALYZE, VERBOSE)
+SELECT v.user_id, p.value AS profile
+FROM vip_users v
+JOIN bulk_user_profiles p ON v.user_id = p.field;
+
+-- Same shape — aggregation over the pushdown plan
+EXPLAIN (ANALYZE, VERBOSE)
+SELECT
+    v.user_id,
+    p.value AS profile
+FROM vip_users v
+JOIN bulk_user_profiles p ON v.user_id = p.field
+ORDER BY v.user_id
+LIMIT 10;
+
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+
+-- ============================================================
+-- PART 3: Pushdown JOIN — Redis FDW × Redis FDW
+-- ============================================================
+-- Driver is the SET membership lookup. We pick a small slice
+-- (50 active users via IN list) so the outer side is tiny and
+-- the inner HASH lookups become per-row HGETs.
+
+-- ---- 3A. SET pushdown: WHERE member IN (...) → SISMEMBER × N ----
+EXPLAIN (ANALYZE, VERBOSE)
+SELECT a.member
+FROM bulk_active_users a
+WHERE a.member IN (
+    'user:1','user:42','user:100','user:777','user:9999',
+    'user:12345','user:55555','user:88888','user:99999','user:99000'
+);
+
+-- ---- 3B. Two-sided pushdown: small SET filter feeds HASH HGETs ----
+-- Outer: SET filtered by IN list (pushed to SISMEMBER per item).
+-- Inner: HASH looked up by field = a.member (pushed to HGET).
+SET LOCAL enable_hashjoin = off;
+SET LOCAL enable_mergejoin = off;
+
+EXPLAIN (ANALYZE, VERBOSE)
+SELECT a.member AS user_id, p.value AS profile
+FROM bulk_active_users a
+JOIN bulk_user_profiles p ON p.field = a.member
+WHERE a.member IN (
+    'user:1','user:42','user:100','user:777','user:9999',
+    'user:12345','user:55555','user:88888','user:99999','user:99000'
+);
+
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+
+-- ---- 3C. Contrast: same JOIN without the selective filter ----
+-- Both sides scanned fully (HGETALL + SMEMBERS) and hash-joined
+-- in PG. Useful to show the default plan when the driver is large.
+EXPLAIN (ANALYZE, VERBOSE)
+SELECT COUNT(*) AS active_with_profile
+FROM bulk_user_profiles p
+JOIN bulk_active_users a ON p.field = a.member;
+
+-- ============================================================
+-- PART 4: ZSet score-range pushdown at scale
+-- ============================================================
+-- 100K leaderboard entries; selective range becomes ZRANGEBYSCORE
+-- and fetches ~1% of the data instead of all 100K.
+
+CREATE FOREIGN TABLE bulk_leaderboard (member text, score numeric)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'zset',
+        table_key_prefix 'demo11:leaderboard',
+        batch_size '10000'
+    );
+
+INSERT INTO bulk_leaderboard
+SELECT 'player:' || g::text, (random() * 100000)::int
+FROM generate_series(1, :ROWS) g;
+
+-- Full scan baseline
+EXPLAIN (ANALYZE, VERBOSE)
+SELECT COUNT(*) FROM bulk_leaderboard;
+
+-- Pushed score range — ZRANGEBYSCORE, fetches only top ~1%
+EXPLAIN (ANALYZE, VERBOSE)
+SELECT * FROM bulk_leaderboard
+WHERE score >= 99000
+ORDER BY score DESC;
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+TRUNCATE bulk_user_profiles_slow;
+TRUNCATE bulk_user_profiles;
+TRUNCATE bulk_active_users;
+TRUNCATE bulk_leaderboard;
+DROP FOREIGN TABLE bulk_user_profiles_slow;
+DROP FOREIGN TABLE bulk_user_profiles;
+DROP FOREIGN TABLE bulk_active_users;
+DROP FOREIGN TABLE bulk_leaderboard;
+DROP TABLE vip_users;

--- a/examples/12_copy_from_file.sql
+++ b/examples/12_copy_from_file.sql
@@ -1,0 +1,80 @@
+-- ============================================================
+-- Demo 12: COPY FROM (file-based bulk load)
+-- ============================================================
+-- COPY FROM uses the BeginForeignInsert / EndForeignInsert path
+-- which lets the FDW pipeline rows in batches.
+--
+-- This file:
+--   1. Generates a 10K-row CSV server-side using COPY ... TO PROGRAM
+--      so the demo is fully self-contained (no manual file prep).
+--   2. Loads it back into a Redis hash via COPY FROM.
+--
+-- If your environment forbids COPY ... TO PROGRAM, replace it with
+-- a pre-generated CSV path. The COPY FROM portion is the actual
+-- feature being demonstrated.
+-- ============================================================
+
+\timing on
+
+-- ------------------------------------------------------------
+-- Step 1: Generate a 10K-row CSV file via a local staging table
+-- ------------------------------------------------------------
+CREATE TEMPORARY TABLE staging_events (field text, value text);
+
+INSERT INTO staging_events
+SELECT
+    'evt:' || g::text,
+    '{"type":"click","page":"/p/' || (g % 50) || '","ts":' || (1700000000 + g) || '}'
+FROM generate_series(1, 10000) g;
+
+-- Write to /tmp/redis_fdw_events.csv (adjust path for Windows demos)
+COPY staging_events TO '/tmp/redis_fdw_events.csv' WITH (FORMAT csv);
+
+-- ------------------------------------------------------------
+-- Step 2: COPY FROM file into a Redis foreign table
+-- ------------------------------------------------------------
+CREATE FOREIGN TABLE copy_events (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'copy:events:log',
+        batch_size '5000'
+    );
+
+COPY copy_events FROM '/tmp/redis_fdw_events.csv' WITH (FORMAT csv);
+
+-- ------------------------------------------------------------
+-- Step 3: Verify
+-- ------------------------------------------------------------
+SELECT COUNT(*) AS events_loaded FROM copy_events;
+SELECT * FROM copy_events WHERE field = 'evt:1';
+SELECT * FROM copy_events WHERE field = 'evt:5000';
+
+-- ------------------------------------------------------------
+-- Bonus: COPY FROM stdin (inline data, no file needed)
+-- ------------------------------------------------------------
+CREATE FOREIGN TABLE copy_stdin_demo (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'copy:stdin:demo'
+    );
+
+COPY copy_stdin_demo (field, value) FROM stdin WITH (FORMAT csv);
+sku:1001,"{""name"":""keyboard"",""price"":129.99}"
+sku:1002,"{""name"":""mouse"",""price"":49.99}"
+sku:1003,"{""name"":""monitor"",""price"":399.99}"
+\.
+
+SELECT * FROM copy_stdin_demo;
+
+-- ------------------------------------------------------------
+-- Cleanup
+-- ------------------------------------------------------------
+TRUNCATE copy_events;
+TRUNCATE copy_stdin_demo;
+DROP FOREIGN TABLE copy_events;
+DROP FOREIGN TABLE copy_stdin_demo;
+DROP TABLE staging_events;

--- a/examples/12_copy_from_file.sql
+++ b/examples/12_copy_from_file.sql
@@ -1,23 +1,19 @@
 -- ============================================================
--- Demo 12: COPY FROM (file-based bulk load)
+-- Demo 12: COPY FROM (bulk load into Redis)
 -- ============================================================
 -- COPY FROM uses the BeginForeignInsert / EndForeignInsert path
 -- which lets the FDW pipeline rows in batches.
 --
--- This file:
---   1. Generates a 10K-row CSV server-side using COPY ... TO PROGRAM
---      so the demo is fully self-contained (no manual file prep).
---   2. Loads it back into a Redis hash via COPY FROM.
---
--- If your environment forbids COPY ... TO PROGRAM, replace it with
--- a pre-generated CSV path. The COPY FROM portion is the actual
--- feature being demonstrated.
+-- This file demonstrates:
+--   1. INSERT ... SELECT from a local table into a Redis hash (uses
+--      the same BeginForeignInsert / batch pipeline path as COPY FROM)
+--   2. COPY FROM stdin (inline data, no file needed)
 -- ============================================================
 
 \timing on
 
 -- ------------------------------------------------------------
--- Step 1: Generate a 10K-row CSV file via a local staging table
+-- Step 1: Generate 10K rows in a staging table, bulk-load into Redis
 -- ------------------------------------------------------------
 CREATE TEMPORARY TABLE staging_events (field text, value text);
 
@@ -27,12 +23,6 @@ SELECT
     '{"type":"click","page":"/p/' || (g % 50) || '","ts":' || (1700000000 + g) || '}'
 FROM generate_series(1, 10000) g;
 
--- Write to /tmp/redis_fdw_events.csv (adjust path for Windows demos)
-COPY staging_events TO '/tmp/redis_fdw_events.csv' WITH (FORMAT csv);
-
--- ------------------------------------------------------------
--- Step 2: COPY FROM file into a Redis foreign table
--- ------------------------------------------------------------
 CREATE FOREIGN TABLE copy_events (field text, value text)
     SERVER redis_server
     OPTIONS (
@@ -42,7 +32,8 @@ CREATE FOREIGN TABLE copy_events (field text, value text)
         batch_size '5000'
     );
 
-COPY copy_events FROM '/tmp/redis_fdw_events.csv' WITH (FORMAT csv);
+-- Bulk-load via INSERT ... SELECT (same pipeline as COPY FROM)
+INSERT INTO copy_events SELECT * FROM staging_events;
 
 -- ------------------------------------------------------------
 -- Step 3: Verify

--- a/examples/13_truncate.sql
+++ b/examples/13_truncate.sql
@@ -1,0 +1,64 @@
+-- ============================================================
+-- Demo 13: TRUNCATE
+-- ============================================================
+-- TRUNCATE on a Redis foreign table removes the underlying key(s):
+--   Single-key table:  DEL / UNLINK on the one key
+--   Multi-key pattern: SCAN + UNLINK for every matching key
+-- ============================================================
+
+\timing on
+
+-- ------------------------------------------------------------
+-- Part A: Single-key TRUNCATE
+-- ------------------------------------------------------------
+CREATE FOREIGN TABLE demo_trunc_hash (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'trunc:test:hash'
+    );
+
+INSERT INTO demo_trunc_hash VALUES ('a', '1'), ('b', '2'), ('c', '3');
+SELECT * FROM demo_trunc_hash;
+
+TRUNCATE demo_trunc_hash;
+SELECT * FROM demo_trunc_hash;  -- empty
+
+-- ------------------------------------------------------------
+-- Part B: Multi-key pattern TRUNCATE (SCAN + UNLINK)
+-- ------------------------------------------------------------
+CREATE FOREIGN TABLE demo_trunc_seed1 (value text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'trunc:multi:1');
+CREATE FOREIGN TABLE demo_trunc_seed2 (value text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'trunc:multi:2');
+CREATE FOREIGN TABLE demo_trunc_seed3 (value text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'trunc:multi:3');
+
+INSERT INTO demo_trunc_seed1 VALUES ('a');
+INSERT INTO demo_trunc_seed2 VALUES ('b');
+INSERT INTO demo_trunc_seed3 VALUES ('c');
+
+CREATE FOREIGN TABLE demo_trunc_pattern (key text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'string',
+        table_key_prefix 'trunc:multi:*'
+    );
+
+SELECT * FROM demo_trunc_pattern;  -- 3 rows
+TRUNCATE demo_trunc_pattern;       -- removes all matching keys
+SELECT * FROM demo_trunc_pattern;  -- empty
+
+-- ------------------------------------------------------------
+-- Cleanup
+-- ------------------------------------------------------------
+DROP FOREIGN TABLE demo_trunc_hash;
+DROP FOREIGN TABLE demo_trunc_seed1;
+DROP FOREIGN TABLE demo_trunc_seed2;
+DROP FOREIGN TABLE demo_trunc_seed3;
+DROP FOREIGN TABLE demo_trunc_pattern;

--- a/examples/14_import_foreign_schema.sql
+++ b/examples/14_import_foreign_schema.sql
@@ -2,30 +2,30 @@
 -- Demo 14: IMPORT FOREIGN SCHEMA
 -- ============================================================
 -- IMPORT FOREIGN SCHEMA auto-discovers Redis keys matching a glob
--- pattern, detects each key's type, and generates the corresponding
--- CREATE FOREIGN TABLE DDL automatically.
+-- pattern, groups them by shared prefix (up to last ':'), detects
+-- each group's type, and generates a multi-key FOREIGN TABLE per group.
 -- ============================================================
 
 \timing on
 
 -- ------------------------------------------------------------
--- Step 1: Seed some Redis keys of different types
+-- Step 1: Seed some Redis keys of different types/prefixes
 -- ------------------------------------------------------------
 CREATE FOREIGN TABLE demo_import_s1 (value text)
     SERVER redis_server
-    OPTIONS (database '0', table_type 'string', table_key_prefix 'import:app:config');
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'import:config:version');
 
-CREATE FOREIGN TABLE demo_import_s2 (field text, value text)
+CREATE FOREIGN TABLE demo_import_s2 (value text)
     SERVER redis_server
-    OPTIONS (database '0', table_type 'hash', table_key_prefix 'import:app:settings');
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'import:config:env');
 
-CREATE FOREIGN TABLE demo_import_s3 (member text)
+CREATE FOREIGN TABLE demo_import_s3 (field text, value text)
     SERVER redis_server
-    OPTIONS (database '0', table_type 'set', table_key_prefix 'import:app:flags');
+    OPTIONS (database '0', table_type 'hash', table_key_prefix 'import:user:1001');
 
 INSERT INTO demo_import_s1 VALUES ('v1.0');
-INSERT INTO demo_import_s2 VALUES ('theme', 'dark');
-INSERT INTO demo_import_s3 VALUES ('beta');
+INSERT INTO demo_import_s2 VALUES ('production');
+INSERT INTO demo_import_s3 VALUES ('name', 'Alice');
 
 -- Drop the seeding tables; the keys remain in Redis
 DROP FOREIGN TABLE demo_import_s1;
@@ -34,6 +34,9 @@ DROP FOREIGN TABLE demo_import_s3;
 
 -- ------------------------------------------------------------
 -- Step 2: IMPORT - the FDW discovers the keys and types
+-- Keys with same prefix group into one multi-key table:
+--   import:config:version + import:config:env → import_config (string, multi-key)
+--   import:user:1001 → import_user (hash, single-key)
 -- ------------------------------------------------------------
 IMPORT FOREIGN SCHEMA "import:*"
     FROM SERVER redis_server
@@ -44,14 +47,14 @@ SELECT relname FROM pg_class
     WHERE relkind = 'f' AND relname LIKE 'import%'
     ORDER BY relname;
 
--- Query them as ordinary foreign tables
-SELECT * FROM "import:app:config";
-SELECT * FROM "import:app:settings";
-SELECT * FROM "import:app:flags";
+-- Query the auto-created multi-key string table
+SELECT * FROM import_config;
+
+-- Query the auto-created hash table
+SELECT * FROM import_user;
 
 -- ------------------------------------------------------------
 -- Cleanup
 -- ------------------------------------------------------------
-DROP FOREIGN TABLE IF EXISTS "import:app:config";
-DROP FOREIGN TABLE IF EXISTS "import:app:settings";
-DROP FOREIGN TABLE IF EXISTS "import:app:flags";
+DROP FOREIGN TABLE IF EXISTS import_config;
+DROP FOREIGN TABLE IF EXISTS import_user;

--- a/examples/14_import_foreign_schema.sql
+++ b/examples/14_import_foreign_schema.sql
@@ -1,0 +1,57 @@
+-- ============================================================
+-- Demo 14: IMPORT FOREIGN SCHEMA
+-- ============================================================
+-- IMPORT FOREIGN SCHEMA auto-discovers Redis keys matching a glob
+-- pattern, detects each key's type, and generates the corresponding
+-- CREATE FOREIGN TABLE DDL automatically.
+-- ============================================================
+
+\timing on
+
+-- ------------------------------------------------------------
+-- Step 1: Seed some Redis keys of different types
+-- ------------------------------------------------------------
+CREATE FOREIGN TABLE demo_import_s1 (value text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'string', table_key_prefix 'import:app:config');
+
+CREATE FOREIGN TABLE demo_import_s2 (field text, value text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'hash', table_key_prefix 'import:app:settings');
+
+CREATE FOREIGN TABLE demo_import_s3 (member text)
+    SERVER redis_server
+    OPTIONS (database '0', table_type 'set', table_key_prefix 'import:app:flags');
+
+INSERT INTO demo_import_s1 VALUES ('v1.0');
+INSERT INTO demo_import_s2 VALUES ('theme', 'dark');
+INSERT INTO demo_import_s3 VALUES ('beta');
+
+-- Drop the seeding tables; the keys remain in Redis
+DROP FOREIGN TABLE demo_import_s1;
+DROP FOREIGN TABLE demo_import_s2;
+DROP FOREIGN TABLE demo_import_s3;
+
+-- ------------------------------------------------------------
+-- Step 2: IMPORT - the FDW discovers the keys and types
+-- ------------------------------------------------------------
+IMPORT FOREIGN SCHEMA "import:*"
+    FROM SERVER redis_server
+    INTO public;
+
+-- List the tables the FDW created for us
+SELECT relname FROM pg_class
+    WHERE relkind = 'f' AND relname LIKE 'import%'
+    ORDER BY relname;
+
+-- Query them as ordinary foreign tables
+SELECT * FROM "import:app:config";
+SELECT * FROM "import:app:settings";
+SELECT * FROM "import:app:flags";
+
+-- ------------------------------------------------------------
+-- Cleanup
+-- ------------------------------------------------------------
+DROP FOREIGN TABLE IF EXISTS "import:app:config";
+DROP FOREIGN TABLE IF EXISTS "import:app:settings";
+DROP FOREIGN TABLE IF EXISTS "import:app:flags";

--- a/examples/15_explain_and_planning.sql
+++ b/examples/15_explain_and_planning.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- Demo 15: EXPLAIN Output & Query Planning
+-- ============================================================
+-- The FDW provides detailed EXPLAIN output showing:
+--   - Redis server connection details
+--   - Key prefix and table type
+--   - Pushdown conditions applied
+--   - Batch size for bulk operations
+-- ============================================================
+
+CREATE FOREIGN TABLE demo_explain_hash (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'explain:demo:hash'
+    );
+
+INSERT INTO demo_explain_hash VALUES ('a', '1'), ('b', '2'), ('c', '3');
+
+-- Basic EXPLAIN shows the Foreign Scan node
+EXPLAIN SELECT * FROM demo_explain_hash;
+
+-- VERBOSE shows server, key, type, and pushdown details
+EXPLAIN (VERBOSE) SELECT * FROM demo_explain_hash;
+
+-- With pushdown condition
+EXPLAIN (VERBOSE) SELECT value FROM demo_explain_hash WHERE field = 'a';
+
+-- EXPLAIN ANALYZE shows actual execution time
+EXPLAIN (ANALYZE, VERBOSE) SELECT * FROM demo_explain_hash;
+
+-- EXPLAIN for modification operations
+EXPLAIN (VERBOSE) INSERT INTO demo_explain_hash VALUES ('d', '4');
+EXPLAIN (VERBOSE) UPDATE demo_explain_hash SET value = '99' WHERE field = 'a';
+EXPLAIN (VERBOSE) DELETE FROM demo_explain_hash WHERE field = 'b';
+
+-- Cleanup
+DROP FOREIGN TABLE demo_explain_hash;

--- a/examples/16_real_world_session_store.sql
+++ b/examples/16_real_world_session_store.sql
@@ -1,0 +1,79 @@
+-- ============================================================
+-- Demo 16: Real-World Use Case - Session Store
+-- ============================================================
+-- Common pattern: using Redis FDW as a session/cache layer
+-- that can be queried with standard SQL alongside local tables
+-- ============================================================
+
+-- Create local user table (simulating your app's database)
+CREATE TEMPORARY TABLE app_users (
+    user_id text PRIMARY KEY,
+    username text,
+    email text,
+    created_at timestamp DEFAULT now()
+);
+
+INSERT INTO app_users VALUES
+    ('u:1001', 'alice', 'alice@corp.com'),
+    ('u:1002', 'bob', 'bob@corp.com'),
+    ('u:1003', 'charlie', 'charlie@corp.com');
+
+-- Redis-backed session store (Hash per session)
+CREATE FOREIGN TABLE session_store (field text, value text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'hash',
+        table_key_prefix 'session:active'
+    );
+
+-- Simulate active sessions
+INSERT INTO session_store VALUES ('u:1001', '{"ip":"10.0.0.1","last_seen":"2024-01-15T10:30:00Z"}');
+INSERT INTO session_store VALUES ('u:1003', '{"ip":"10.0.0.5","last_seen":"2024-01-15T10:45:00Z"}');
+
+-- Redis-backed feature flags (Set)
+CREATE FOREIGN TABLE feature_flags (member text)
+    SERVER redis_server
+    OPTIONS (
+        database '0',
+        table_type 'set',
+        table_key_prefix 'features:beta_users'
+    );
+
+INSERT INTO feature_flags VALUES ('u:1001');
+INSERT INTO feature_flags VALUES ('u:1002');
+
+-- ============================================================
+-- Query: Find active users with their session data
+-- ============================================================
+SELECT
+    u.username,
+    u.email,
+    s.value AS session_data
+FROM app_users u
+JOIN session_store s ON u.user_id = s.field;
+
+-- ============================================================
+-- Query: Find beta users who are currently online
+-- ============================================================
+SELECT
+    u.username,
+    u.email
+FROM app_users u
+JOIN feature_flags f ON u.user_id = f.member
+JOIN session_store s ON u.user_id = s.field;
+
+-- ============================================================
+-- Query: All users with their online status
+-- ============================================================
+SELECT
+    u.username,
+    u.email,
+    CASE WHEN s.value IS NOT NULL THEN 'online' ELSE 'offline' END AS status
+FROM app_users u
+LEFT JOIN session_store s ON u.user_id = s.field;
+
+-- Cleanup
+DROP TABLE app_users;
+DROP FOREIGN TABLE session_store;
+DROP FOREIGN TABLE feature_flags;

--- a/examples/17_cluster_mode.sql
+++ b/examples/17_cluster_mode.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- Demo 17: Cluster Mode
+-- ============================================================
+-- Redis FDW supports Redis Cluster (sharded multi-node).
+-- The only difference is adding cluster_mode='true' to the server.
+-- All operations work the same way.
+--
+-- Prerequisites: make setup-redis (starts cluster on ports 7001-7006)
+-- ============================================================
+
+-- Create a cluster server connection
+CREATE SERVER redis_cluster_server
+    FOREIGN DATA WRAPPER redis_wrapper
+    OPTIONS (
+        host_port '127.0.0.1:7001',
+        cluster_mode 'true'
+    );
+
+-- Hash table on the cluster
+CREATE FOREIGN TABLE demo_cluster_hash (field text, value text)
+    SERVER redis_cluster_server
+    OPTIONS (
+        table_type 'hash',
+        table_key_prefix 'cluster:config'
+    );
+
+-- Operations work identically to standalone
+INSERT INTO demo_cluster_hash VALUES ('version', '3.2.1');
+INSERT INTO demo_cluster_hash VALUES ('env', 'production');
+INSERT INTO demo_cluster_hash VALUES ('region', 'us-west-2');
+
+SELECT * FROM demo_cluster_hash;
+SELECT value FROM demo_cluster_hash WHERE field = 'env';
+
+-- Set table on the cluster
+CREATE FOREIGN TABLE demo_cluster_set (member text)
+    SERVER redis_cluster_server
+    OPTIONS (
+        table_type 'set',
+        table_key_prefix 'cluster:nodes:active'
+    );
+
+INSERT INTO demo_cluster_set VALUES ('node-1.internal');
+INSERT INTO demo_cluster_set VALUES ('node-2.internal');
+INSERT INTO demo_cluster_set VALUES ('node-3.internal');
+
+SELECT * FROM demo_cluster_set;
+
+-- Cleanup
+DROP FOREIGN TABLE demo_cluster_hash;
+DROP FOREIGN TABLE demo_cluster_set;
+DROP SERVER redis_cluster_server;

--- a/examples/99_cleanup.sql
+++ b/examples/99_cleanup.sql
@@ -1,0 +1,17 @@
+-- ============================================================
+-- Cleanup: Remove all demo artifacts
+-- ============================================================
+-- Run this at the end of a demo session to wipe extension state.
+-- Redis keys are NOT removed here — use TRUNCATE on individual
+-- foreign tables (or FLUSHDB on the Redis side) for that.
+-- ============================================================
+
+-- Drop the servers (cascades to all foreign tables)
+DROP SERVER IF EXISTS redis_server CASCADE;
+DROP SERVER IF EXISTS redis_cluster_server CASCADE;
+
+-- Drop the FDW
+DROP FOREIGN DATA WRAPPER IF EXISTS redis_wrapper CASCADE;
+
+-- Drop the extension
+DROP EXTENSION IF EXISTS redis_fdw_rs;

--- a/src/core/column_utils.rs
+++ b/src/core/column_utils.rs
@@ -197,16 +197,31 @@ pub(crate) unsafe fn extract_delete_key(
     let mut is_null = false;
     let datum = exec_get_junk_attribute(plan_slot, state.key_attno, &mut is_null);
 
-    match String::from_datum(datum, is_null) {
-        Some(key_string) => {
-            if key_string.is_empty() {
-                Err("Delete key is empty")
-            } else {
-                Ok(key_string)
-            }
-        }
-        None => Err("Failed to convert datum to string"),
+    if is_null {
+        return Err("Delete key is NULL");
     }
+
+    if let Some(key_string) = String::from_datum(datum, false) {
+        if key_string.is_empty() {
+            return Err("Delete key is empty");
+        }
+        return Ok(key_string);
+    }
+
+    // Fallback for non-text types: use PG output function
+    let tupdesc = (*plan_slot).tts_tupleDescriptor;
+    let attidx = (state.key_attno - 1) as usize;
+    if !tupdesc.is_null() && attidx < (*tupdesc).natts as usize {
+        let attr = crate::utils::helpers::tuple_desc_attr(tupdesc, attidx);
+        let typoid = (*attr).atttypid;
+        let key_string = datum_to_text_string(datum, typoid);
+        if key_string.is_empty() {
+            return Err("Delete key is empty");
+        }
+        return Ok(key_string);
+    }
+
+    Err("Failed to convert datum to string")
 }
 
 #[cfg(test)]

--- a/src/core/column_utils.rs
+++ b/src/core/column_utils.rs
@@ -56,6 +56,19 @@ pub(crate) fn compute_pushdown_column_index(
     }
 }
 
+/// Convert a raw PostgreSQL attribute index to a data-row index after TTL column stripping.
+///
+/// `fetch_dataset` in join execution returns rows without the TTL column.
+/// This adjusts the raw `varattno - 1` index so it points at the correct
+/// position in the TTL-stripped data row.
+pub(crate) fn adjust_column_for_ttl_strip(col: usize, ttl_idx: Option<usize>) -> Option<usize> {
+    match ttl_idx {
+        Some(t) if t == col => None,
+        Some(t) if t < col => Some(col - 1),
+        _ => Some(col),
+    }
+}
+
 pub(crate) unsafe fn datum_to_text_string(datum: pg_sys::Datum, typoid: pg_sys::Oid) -> String {
     if typoid == pg_sys::TEXTOID || typoid == pg_sys::VARCHAROID || typoid == pg_sys::BPCHAROID {
         String::from_datum(datum, false).unwrap_or_default()
@@ -216,5 +229,26 @@ mod tests {
         assert_eq!(compute_pushdown_column_index(Some(1), true), 2);
         // Multi-key, TTL after data columns
         assert_eq!(compute_pushdown_column_index(Some(3), true), 1);
+    }
+
+    #[test]
+    fn test_adjust_column_for_ttl_strip() {
+        // No TTL column
+        assert_eq!(adjust_column_for_ttl_strip(0, None), Some(0));
+        assert_eq!(adjust_column_for_ttl_strip(1, None), Some(1));
+        // TTL at position 0, accessing column 1 → becomes 0 in stripped data
+        assert_eq!(adjust_column_for_ttl_strip(1, Some(0)), Some(0));
+        assert_eq!(adjust_column_for_ttl_strip(2, Some(0)), Some(1));
+        // TTL at position 0, accessing column 0 → None (targeting the TTL column itself)
+        assert_eq!(adjust_column_for_ttl_strip(0, Some(0)), None);
+        // TTL at position 1, accessing column 0 → unchanged
+        assert_eq!(adjust_column_for_ttl_strip(0, Some(1)), Some(0));
+        // TTL at position 1, accessing column 1 → None (targeting TTL)
+        assert_eq!(adjust_column_for_ttl_strip(1, Some(1)), None);
+        // TTL at position 1, accessing column 2 → becomes 1
+        assert_eq!(adjust_column_for_ttl_strip(2, Some(1)), Some(1));
+        // TTL after the target column
+        assert_eq!(adjust_column_for_ttl_strip(0, Some(3)), Some(0));
+        assert_eq!(adjust_column_for_ttl_strip(1, Some(3)), Some(1));
     }
 }

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -389,9 +389,16 @@ extern "C-unwind" fn begin_foreign_scan(
             RedisTableType::Hash(ref mut h) => h.pushdown_column_index = pushdown_idx,
             RedisTableType::ZSet(ref mut z) => {
                 z.pushdown_column_index = pushdown_idx;
+                // Find the next active (non-dropped, non-TTL) column after pushdown_idx
                 let mut score_idx = pushdown_idx + 1;
-                if Some(score_idx) == state.ttl_column_index {
-                    score_idx += 1;
+                let natts = (*tupdesc).natts as usize;
+                while score_idx < natts {
+                    let attr = tuple_desc_attr(tupdesc, score_idx);
+                    if (*attr).attisdropped || Some(score_idx) == state.ttl_column_index {
+                        score_idx += 1;
+                        continue;
+                    }
+                    break;
                 }
                 z.score_column_index = score_idx;
             }
@@ -671,13 +678,30 @@ unsafe extern "C-unwind" fn add_foreign_update_targets(
     let relid = (*target_relation).rd_id;
     let opts = get_foreign_table_options(relid);
     let table_type = opts.get("table_type").map(|s| s.as_str()).unwrap_or("");
-    let num_data_cols = if ttl_idx.is_some() { natts - 1 } else { natts };
+
+    // Count active (non-dropped, non-TTL) data columns
+    let mut num_data_cols = 0usize;
+    for i in 0..natts {
+        let a = tuple_desc_attr(tupdesc, i);
+        if (*a).attisdropped {
+            continue;
+        }
+        if Some(i) == ttl_idx {
+            continue;
+        }
+        num_data_cols += 1;
+    }
 
     let identity_attno = if table_type == "list" && num_data_cols >= 2 {
-        // For 2-column list (index, value): LREM needs the value column, which is the second non-TTL column
+        // For 2-column list (index, value): LREM needs the value column,
+        // which is the second active non-TTL column
         let mut count = 0usize;
         let mut target = 0usize;
         for i in 0..natts {
+            let a = tuple_desc_attr(tupdesc, i);
+            if (*a).attisdropped {
+                continue;
+            }
             if Some(i) == ttl_idx {
                 continue;
             }
@@ -689,10 +713,20 @@ unsafe extern "C-unwind" fn add_foreign_update_targets(
         }
         target
     } else {
-        match ttl_idx {
-            Some(0) => 1,
-            _ => 0,
+        // Default: first active non-TTL column
+        let mut target = 0usize;
+        for i in 0..natts {
+            let a = tuple_desc_attr(tupdesc, i);
+            if (*a).attisdropped {
+                continue;
+            }
+            if Some(i) == ttl_idx {
+                continue;
+            }
+            target = i;
+            break;
         }
+        target
     };
 
     let attr = *tuple_desc_attr(tupdesc, identity_attno);

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -666,10 +666,33 @@ unsafe extern "C-unwind" fn add_foreign_update_targets(
     log!("---> add_foreign_update_targets");
     let tupdesc = relation_get_descr(target_relation);
     let ttl_idx = detect_ttl_column(tupdesc);
+    let natts = (*tupdesc).natts as usize;
 
-    let identity_attno = match ttl_idx {
-        Some(0) => 1,
-        _ => 0,
+    let relid = (*target_relation).rd_id;
+    let opts = get_foreign_table_options(relid);
+    let table_type = opts.get("table_type").map(|s| s.as_str()).unwrap_or("");
+    let num_data_cols = if ttl_idx.is_some() { natts - 1 } else { natts };
+
+    let identity_attno = if table_type == "list" && num_data_cols >= 2 {
+        // For 2-column list (index, value): LREM needs the value column, which is the second non-TTL column
+        let mut count = 0usize;
+        let mut target = 0usize;
+        for i in 0..natts {
+            if Some(i) == ttl_idx {
+                continue;
+            }
+            count += 1;
+            if count == 2 {
+                target = i;
+                break;
+            }
+        }
+        target
+    } else {
+        match ttl_idx {
+            Some(0) => 1,
+            _ => 0,
+        }
     };
 
     let attr = *tuple_desc_attr(tupdesc, identity_attno);

--- a/src/core/handlers.rs
+++ b/src/core/handlers.rs
@@ -111,6 +111,10 @@ extern "C-unwind" fn get_foreign_rel_size(
             state.table_type = RedisTableType::from_str(table_type_str);
         }
 
+        let rel = pg_sys::relation_open(foreigntableid, pg_sys::AccessShareLock as i32);
+        state.ttl_column_index = detect_ttl_column((*rel).rd_att);
+        pg_sys::relation_close(rel, pg_sys::AccessShareLock as i32);
+
         if let Err(e) = state.init_redis_connection_from_options() {
             log!(
                 "Could not connect to Redis for cost estimation, using defaults: {}",
@@ -383,7 +387,14 @@ extern "C-unwind" fn begin_foreign_scan(
             compute_pushdown_column_index(state.ttl_column_index, state.is_multi_key);
         match &mut state.table_type {
             RedisTableType::Hash(ref mut h) => h.pushdown_column_index = pushdown_idx,
-            RedisTableType::ZSet(ref mut z) => z.pushdown_column_index = pushdown_idx,
+            RedisTableType::ZSet(ref mut z) => {
+                z.pushdown_column_index = pushdown_idx;
+                let mut score_idx = pushdown_idx + 1;
+                if Some(score_idx) == state.ttl_column_index {
+                    score_idx += 1;
+                }
+                z.score_column_index = score_idx;
+            }
             RedisTableType::Stream(ref mut s) => s.pushdown_column_index = pushdown_idx,
             _ => {}
         }
@@ -653,11 +664,20 @@ unsafe extern "C-unwind" fn add_foreign_update_targets(
     target_relation: pgrx::pg_sys::Relation,
 ) {
     log!("---> add_foreign_update_targets");
-    let attr = *tuple_desc_attr(relation_get_descr(target_relation), 0);
+    let tupdesc = relation_get_descr(target_relation);
+    let ttl_idx = detect_ttl_column(tupdesc);
+
+    let identity_attno = match ttl_idx {
+        Some(0) => 1,
+        _ => 0,
+    };
+
+    let attr = *tuple_desc_attr(tupdesc, identity_attno);
+    let varattno = (identity_attno as i16) + 1;
 
     let var = pg_sys::makeVar(
         rtindex as _,
-        1,
+        varattno,
         attr.atttypid,
         attr.atttypmod,
         pg_sys::InvalidOid,

--- a/src/core/state_manager.rs
+++ b/src/core/state_manager.rs
@@ -276,6 +276,24 @@ impl RedisFdwState {
                 return true;
             }
 
+            // Use direct load for ZSet score-range conditions (ZRANGEBYSCORE is O(log N + M))
+            if let RedisTableType::ZSet(ref z) = self.table_type {
+                let score_idx = z.score_column_index;
+                let has_score_range = analysis.pushable_conditions.iter().any(|c| {
+                    c.column_index == score_idx
+                        && matches!(
+                            c.operator,
+                            ComparisonOperator::GreaterThan
+                                | ComparisonOperator::GreaterThanOrEqual
+                                | ComparisonOperator::LessThan
+                                | ComparisonOperator::LessThanOrEqual
+                        )
+                });
+                if has_score_range {
+                    return true;
+                }
+            }
+
             // Use direct load if we have LIMIT/OFFSET (load_data handles it efficiently)
             if analysis.has_limit_pushdown() {
                 return true;
@@ -1050,8 +1068,7 @@ impl RedisFdwState {
 
         match &mut self.table_type {
             RedisTableType::Hash(ref mut t) => {
-                // param_column == 0 means lookup by field name → HGET
-                if self.param_column == 0 {
+                if self.param_column == t.pushdown_column_index {
                     let val: Option<String> = match redis::cmd("HGET")
                         .arg(&self.table_key_prefix)
                         .arg(param_value)
@@ -1098,8 +1115,7 @@ impl RedisFdwState {
                 }
             }
             RedisTableType::ZSet(ref mut t) => {
-                // param_column == 0 means lookup by member → ZSCORE
-                if self.param_column == 0 {
+                if self.param_column == t.pushdown_column_index {
                     let score: Option<f64> = match redis::cmd("ZSCORE")
                         .arg(&self.table_key_prefix)
                         .arg(param_value)
@@ -1126,8 +1142,11 @@ impl RedisFdwState {
                 false
             }
             RedisTableType::String(ref mut t) => {
-                // Multi-key mode: param_column == 0 means lookup by key → GET
-                if self.is_multi_key && self.param_column == 0 {
+                let expected_col = crate::core::column_utils::compute_pushdown_column_index(
+                    self.ttl_column_index,
+                    false,
+                );
+                if self.is_multi_key && self.param_column == expected_col {
                     let val: Option<String> = match redis::cmd("GET").arg(param_value).query(conn) {
                         Ok(v) => v,
                         Err(e) => {

--- a/src/join/planner.rs
+++ b/src/join/planner.rs
@@ -1,5 +1,10 @@
 use crate::{
-    core::{column_utils::state_from_ptr, state_manager::RedisFdwState},
+    core::{
+        column_utils::{
+            adjust_column_for_ttl_strip, compute_pushdown_column_index, state_from_ptr,
+        },
+        state_manager::RedisFdwState,
+    },
     join::types::{RedisJoinState, RedisJoinType},
     query::cost_estimation::costs,
     tables::types::RedisTableType,
@@ -13,12 +18,88 @@ pub(crate) unsafe fn add_parameterized_paths(
     baserel: *mut pg_sys::RelOptInfo,
     state: &RedisFdwState,
 ) {
+    let my_relids = (*baserel).relids;
+
+    let pushdown_col = compute_pushdown_column_index(state.ttl_column_index, false);
+
+    if (*baserel).has_eclass_joins {
+        let ec_list = (*root).eq_classes;
+        if !ec_list.is_null() {
+            let ec_len = pg_sys::list_length(ec_list);
+            for i in 0..ec_len {
+                let ec = pg_sys::list_nth(ec_list, i) as *mut pg_sys::EquivalenceClass;
+                if ec.is_null() {
+                    continue;
+                }
+
+                let ec_members = (*ec).ec_members;
+                if ec_members.is_null() {
+                    continue;
+                }
+
+                let mut has_my_pushdown_col = false;
+                let mut outer_relids_for_ec: *mut pg_sys::Bitmapset = ptr::null_mut();
+
+                let mem_len = pg_sys::list_length(ec_members);
+                for j in 0..mem_len {
+                    let em = pg_sys::list_nth(ec_members, j) as *mut pg_sys::EquivalenceMember;
+                    if em.is_null() {
+                        continue;
+                    }
+
+                    let em_expr = (*em).em_expr as *mut pg_sys::Node;
+                    if em_expr.is_null() {
+                        continue;
+                    }
+                    if (*em_expr).type_ != pg_sys::NodeTag::T_Var {
+                        continue;
+                    }
+
+                    let var = &*(em_expr as *mut pg_sys::Var);
+
+                    if pg_sys::bms_is_member(var.varno as i32, my_relids) {
+                        let col_idx = (var.varattno - 1) as usize;
+                        if col_idx == pushdown_col {
+                            has_my_pushdown_col = true;
+                        }
+                    } else if var.varno > 0 {
+                        outer_relids_for_ec =
+                            pg_sys::bms_add_member(outer_relids_for_ec, var.varno as i32);
+                    }
+                }
+
+                if has_my_pushdown_col && !outer_relids_for_ec.is_null() {
+                    let param_path = pg_sys::create_foreignscan_path(
+                        root,
+                        baserel,
+                        ptr::null_mut(),
+                        1.0,
+                        #[cfg(feature = "pg18")]
+                        0,
+                        costs::CPU_TUPLE_COST,
+                        costs::PARAMETERIZED_LOOKUP_COST,
+                        ptr::null_mut(),
+                        outer_relids_for_ec,
+                        ptr::null_mut(),
+                        #[cfg(any(feature = "pg17", feature = "pg18"))]
+                        ptr::null_mut(),
+                        ptr::null_mut(),
+                    );
+                    pg_sys::add_path(baserel, param_path as *mut pg_sys::Path);
+                    log!(
+                        "Added EC parameterized path for pushdown col {} with outer relids",
+                        pushdown_col
+                    );
+                }
+            }
+        }
+    }
+
     let joininfo = (*baserel).joininfo;
     if joininfo.is_null() {
         return;
     }
 
-    let my_relids = (*baserel).relids;
     let list_len = pg_sys::list_length(joininfo);
 
     for i in 0..list_len {
@@ -73,10 +154,10 @@ pub(crate) unsafe fn add_parameterized_paths(
         let my_col_idx = (my_col_attno - 1) as usize;
 
         let valid = match &state.table_type {
-            RedisTableType::Hash(_) => my_col_idx == 0,
-            RedisTableType::Set(_) => my_col_idx == 0,
-            RedisTableType::ZSet(_) => my_col_idx == 0,
-            RedisTableType::String(_) if state.is_multi_key => my_col_idx == 0,
+            RedisTableType::Hash(_) => my_col_idx == pushdown_col,
+            RedisTableType::Set(_) => my_col_idx == pushdown_col,
+            RedisTableType::ZSet(_) => my_col_idx == pushdown_col,
+            RedisTableType::String(_) if state.is_multi_key => my_col_idx == pushdown_col,
             _ => false,
         };
         if !valid {
@@ -93,8 +174,8 @@ pub(crate) unsafe fn add_parameterized_paths(
             1.0,
             #[cfg(feature = "pg18")]
             0,
-            costs::NETWORK_ROUND_TRIP,
-            costs::NETWORK_ROUND_TRIP + costs::CPU_TUPLE_COST,
+            costs::CPU_TUPLE_COST,
+            costs::PARAMETERIZED_LOOKUP_COST,
             ptr::null_mut(),
             required_outer,
             ptr::null_mut(),
@@ -372,6 +453,14 @@ pub(crate) unsafe extern "C-unwind" fn get_foreign_join_paths(
         return;
     }
 
+    if (matches!(outer_state.table_type, RedisTableType::String(_)) && !outer_state.is_multi_key)
+        || (matches!(inner_state.table_type, RedisTableType::String(_))
+            && !inner_state.is_multi_key)
+    {
+        log!("Single-key String table detected, join pushdown not supported");
+        return;
+    }
+
     if !(*outerrel).baserestrictinfo.is_null()
         && pg_sys::list_length((*outerrel).baserestrictinfo) > 0
     {
@@ -392,6 +481,23 @@ pub(crate) unsafe extern "C-unwind" fn get_foreign_join_paths(
             return;
         }
     };
+
+    let join_col_outer =
+        match adjust_column_for_ttl_strip(join_col_outer, outer_state.ttl_column_index) {
+            Some(col) => col,
+            None => {
+                log!("Join condition targets TTL column on outer relation, cannot push down");
+                return;
+            }
+        };
+    let join_col_inner =
+        match adjust_column_for_ttl_strip(join_col_inner, inner_state.ttl_column_index) {
+            Some(col) => col,
+            None => {
+                log!("Join condition targets TTL column on inner relation, cannot push down");
+                return;
+            }
+        };
 
     log!(
         "Detected join columns: outer={}, inner={}",

--- a/src/query/cost_estimation.rs
+++ b/src/query/cost_estimation.rs
@@ -50,6 +50,11 @@ pub mod costs {
 
     /// Minimum selectivity when SCAN sample finds no matches but DB is non-empty
     pub const MIN_SCAN_SELECTIVITY: f64 = 0.01;
+
+    /// Cost of a single parameterized point-lookup (HGET/SISMEMBER/ZSCORE)
+    /// on a pooled connection — much cheaper than a full NETWORK_ROUND_TRIP
+    /// because connection is already established and the command is O(1)
+    pub const PARAMETERIZED_LOOKUP_COST: f64 = 0.5;
 }
 
 /// Statistics gathered from Redis for cost estimation

--- a/src/tables/implementations/zset.rs
+++ b/src/tables/implementations/zset.rs
@@ -12,11 +12,22 @@ use crate::{
     },
 };
 
+/// Parse a ZRANGEBYSCORE bound string into f64 for comparison.
+fn parse_bound(s: &str, default: f64) -> f64 {
+    let trimmed = s.strip_prefix('(').unwrap_or(s);
+    match trimmed {
+        "-inf" => f64::NEG_INFINITY,
+        "+inf" => f64::INFINITY,
+        v => v.parse().unwrap_or(default),
+    }
+}
+
 /// Redis Sorted Set table type
 #[derive(Debug, Clone, Default)]
 pub struct RedisZSetTable {
     pub dataset: DataSet,
     pub pushdown_column_index: usize,
+    pub score_column_index: usize,
 }
 
 impl RedisZSetTable {
@@ -24,6 +35,99 @@ impl RedisZSetTable {
         Self {
             dataset: DataSet::Empty,
             pushdown_column_index: 0,
+            score_column_index: 1,
+        }
+    }
+
+    fn load_with_score_range(
+        &mut self,
+        conn: &mut dyn redis::ConnectionLike,
+        key_prefix: &str,
+        score_conditions: &[&PushableCondition],
+        limit_offset: &LimitOffsetInfo,
+    ) -> Result<LoadDataResult, redis::RedisError> {
+        let mut min_score = "-inf".to_string();
+        let mut max_score = "+inf".to_string();
+        let mut min_exclusive = false;
+        let mut max_exclusive = false;
+
+        for cond in score_conditions {
+            match cond.operator {
+                ComparisonOperator::GreaterThan => {
+                    let new_val: f64 = cond.value.parse().unwrap_or(f64::NEG_INFINITY);
+                    let cur_val = parse_bound(&min_score, f64::NEG_INFINITY);
+                    if new_val > cur_val || (new_val == cur_val && !min_exclusive) {
+                        min_score = cond.value.clone();
+                        min_exclusive = true;
+                    }
+                }
+                ComparisonOperator::GreaterThanOrEqual => {
+                    let new_val: f64 = cond.value.parse().unwrap_or(f64::NEG_INFINITY);
+                    let cur_val = parse_bound(&min_score, f64::NEG_INFINITY);
+                    if new_val > cur_val {
+                        min_score = cond.value.clone();
+                        min_exclusive = false;
+                    }
+                }
+                ComparisonOperator::LessThan => {
+                    let new_val: f64 = cond.value.parse().unwrap_or(f64::INFINITY);
+                    let cur_val = parse_bound(&max_score, f64::INFINITY);
+                    if new_val < cur_val || (new_val == cur_val && !max_exclusive) {
+                        max_score = cond.value.clone();
+                        max_exclusive = true;
+                    }
+                }
+                ComparisonOperator::LessThanOrEqual => {
+                    let new_val: f64 = cond.value.parse().unwrap_or(f64::INFINITY);
+                    let cur_val = parse_bound(&max_score, f64::INFINITY);
+                    if new_val < cur_val {
+                        max_score = cond.value.clone();
+                        max_exclusive = false;
+                    }
+                }
+                ComparisonOperator::Equal => {
+                    min_score = cond.value.clone();
+                    max_score = cond.value.clone();
+                    min_exclusive = false;
+                    max_exclusive = false;
+                }
+                _ => {}
+            }
+        }
+
+        let final_min = if min_exclusive {
+            format!("({}", min_score)
+        } else {
+            min_score
+        };
+        let final_max = if max_exclusive {
+            format!("({}", max_score)
+        } else {
+            max_score
+        };
+
+        let mut cmd = redis::cmd("ZRANGEBYSCORE");
+        cmd.arg(key_prefix)
+            .arg(&final_min)
+            .arg(&final_max)
+            .arg("WITHSCORES");
+
+        if limit_offset.has_constraints() {
+            let offset = limit_offset.offset.unwrap_or(0);
+            let limit = limit_offset
+                .limit
+                .unwrap_or(usize::MAX.min(i64::MAX as usize));
+            cmd.arg("LIMIT").arg(offset).arg(limit);
+        }
+
+        let result: Vec<String> = cmd.query(conn)?;
+
+        if result.is_empty() {
+            self.dataset = DataSet::Empty;
+            Ok(LoadDataResult::Empty)
+        } else {
+            self.dataset = DataSet::Filtered(result);
+            Ok(LoadDataResult::FullyLoaded)
         }
     }
 
@@ -124,7 +228,7 @@ impl RedisTableOperations for RedisZSetTable {
         limit_offset: &LimitOffsetInfo,
     ) -> Result<LoadDataResult, redis::RedisError> {
         if let Some(conditions) = conditions {
-            // For ZSet, only pushdown conditions on the member column conditions are left to PostgreSQL's post-filter
+            // Prioritize member equality lookups (ZSCORE is O(1)) over score-range (ZRANGEBYSCORE is O(log N + M))
             let target_idx = self.pushdown_column_index;
             let member_conditions: Vec<PushableCondition> = conditions
                 .iter()
@@ -229,9 +333,25 @@ impl RedisTableOperations for RedisZSetTable {
                                 Ok(LoadDataResult::FullyLoaded)
                             };
                         }
-                        _ => {} // Fall back to full scan
+                        _ => {} // Fall through to score-range check
                     }
                 }
+            }
+
+            // Fallback: score-range conditions (ZRANGEBYSCORE is O(log N + M))
+            let score_idx = self.score_column_index;
+            let score_conditions: Vec<&PushableCondition> = conditions
+                .iter()
+                .filter(|c| c.column_index == score_idx)
+                .collect();
+
+            if !score_conditions.is_empty() {
+                return self.load_with_score_range(
+                    conn,
+                    key_prefix,
+                    &score_conditions,
+                    limit_offset,
+                );
             }
         }
 
@@ -399,7 +519,13 @@ impl RedisTableOperations for RedisZSetTable {
     fn supports_pushdown(&self, operator: &ComparisonOperator) -> bool {
         matches!(
             operator,
-            ComparisonOperator::Equal | ComparisonOperator::In | ComparisonOperator::Like
+            ComparisonOperator::Equal
+                | ComparisonOperator::In
+                | ComparisonOperator::Like
+                | ComparisonOperator::GreaterThan
+                | ComparisonOperator::GreaterThanOrEqual
+                | ComparisonOperator::LessThan
+                | ComparisonOperator::LessThanOrEqual
         )
     }
 

--- a/src/tables/implementations/zset.rs
+++ b/src/tables/implementations/zset.rs
@@ -12,6 +12,14 @@ use crate::{
     },
 };
 
+/// Safe default limit for Redis LIMIT argument (works on both 32-bit and 64-bit).
+/// On 64-bit this equals i64::MAX; on 32-bit it equals u32::MAX (usize::MAX).
+const REDIS_LIMIT_MAX: usize = if (usize::MAX as u128) < (i64::MAX as u128) {
+    usize::MAX
+} else {
+    i64::MAX as usize
+};
+
 /// Parse a ZRANGEBYSCORE bound string into f64 for comparison.
 fn parse_bound(s: &str, default: f64) -> f64 {
     let trimmed = s.strip_prefix('(').unwrap_or(s);
@@ -86,10 +94,19 @@ impl RedisZSetTable {
                     }
                 }
                 ComparisonOperator::Equal => {
-                    min_score = cond.value.clone();
-                    max_score = cond.value.clone();
-                    min_exclusive = false;
-                    max_exclusive = false;
+                    let eq_val: f64 = cond.value.parse().unwrap_or(0.0);
+                    let cur_min = parse_bound(&min_score, f64::NEG_INFINITY);
+                    let cur_max = parse_bound(&max_score, f64::INFINITY);
+
+                    // Only apply if equality value is within current bounds
+                    if eq_val > cur_min || (eq_val == cur_min && !min_exclusive) {
+                        min_score = cond.value.clone();
+                        min_exclusive = false;
+                    }
+                    if eq_val < cur_max || (eq_val == cur_max && !max_exclusive) {
+                        max_score = cond.value.clone();
+                        max_exclusive = false;
+                    }
                 }
                 _ => {}
             }
@@ -114,9 +131,7 @@ impl RedisZSetTable {
 
         if limit_offset.has_constraints() {
             let offset = limit_offset.offset.unwrap_or(0);
-            let limit = limit_offset
-                .limit
-                .unwrap_or(usize::MAX.min(i64::MAX as usize));
+            let limit = limit_offset.limit.unwrap_or(REDIS_LIMIT_MAX);
             cmd.arg("LIMIT").arg(offset).arg(limit);
         }
 
@@ -194,7 +209,7 @@ impl RedisZSetTable {
         // Apply LIMIT/OFFSET to filtered results at the pair level
         if limit_offset.has_constraints() {
             let offset = limit_offset.offset.unwrap_or(0);
-            let limit = limit_offset.limit.unwrap_or(usize::MAX);
+            let limit = limit_offset.limit.unwrap_or(REDIS_LIMIT_MAX);
 
             // filtered_data is [member1, score1, member2, score2, ...]
             // Apply offset/limit at pair granularity (2 elements per pair)
@@ -358,8 +373,8 @@ impl RedisTableOperations for RedisZSetTable {
         // ZSets support efficient range queries with LIMIT/OFFSET using ZRANGE
         let (start, end) = if limit_offset.has_constraints() {
             let offset = limit_offset.offset.unwrap_or(0) as isize;
-            let limit = limit_offset.limit.unwrap_or(usize::MAX);
-            let end_idx = if limit == usize::MAX {
+            let limit = limit_offset.limit.unwrap_or(REDIS_LIMIT_MAX);
+            let end_idx = if limit == REDIS_LIMIT_MAX {
                 -1isize // Redis ZRANGE end=-1 means to the end of sorted set
             } else {
                 offset + (limit as isize) - 1

--- a/src/tests/join_tests.rs
+++ b/src/tests/join_tests.rs
@@ -1274,4 +1274,279 @@ mod tests {
         let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", large_table));
         cleanup_join_fdw();
     }
+
+    // === TTL-position-aware join tests ===
+
+    #[pg_test]
+    fn test_join_hash_ttl_first_with_local() {
+        setup_join_fdw();
+
+        let key_prefix = "join_test:ttl_first_hash";
+        let table_name = "join_ttl_first_hash";
+
+        // TTL column at position 0, before data columns
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {} (ttl bigint, field text, value text)
+             SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}', ttl '3600'
+             );",
+            table_name, SERVER_NAME, TEST_DATABASE, key_prefix
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "INSERT INTO {} (field, value) VALUES ('a', 'val_a'), ('b', 'val_b'), ('c', 'val_c');",
+            table_name
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_ttl_local (id text, name text);").unwrap();
+        Spi::run("INSERT INTO join_ttl_local VALUES ('a', 'Alice'), ('b', 'Bob'), ('d', 'Dave');")
+            .unwrap();
+
+        // Parameterized HGET path should work even with TTL at position 0
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_ttl_local l JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            count, 2,
+            "JOIN with TTL-first hash should find 2 matches (a, b)"
+        );
+
+        // LEFT JOIN
+        let left_count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_ttl_local l LEFT JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            left_count, 3,
+            "LEFT JOIN with TTL-first should return all 3 local rows"
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'a';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'b';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'c';", table_name)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_ttl_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_hash_ttl_middle_with_local() {
+        setup_join_fdw();
+
+        let key_prefix = "join_test:ttl_mid_hash";
+        let table_name = "join_ttl_mid_hash";
+
+        // TTL column between data columns
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {} (field text, ttl bigint, value text)
+             SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}', ttl '3600'
+             );",
+            table_name, SERVER_NAME, TEST_DATABASE, key_prefix
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "INSERT INTO {} (field, value) VALUES ('x', 'val_x'), ('y', 'val_y');",
+            table_name
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_ttl_mid_local (id text);").unwrap();
+        Spi::run("INSERT INTO join_ttl_mid_local VALUES ('x'), ('y'), ('z');").unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_ttl_mid_local l JOIN {} r ON l.id = r.field;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 2, "JOIN with TTL-middle hash should find 2 matches");
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'x';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'y';", table_name)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_ttl_mid_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_zset_ttl_first_with_local() {
+        setup_join_fdw();
+
+        let key_prefix = "join_test:ttl_first_zset";
+        let table_name = "join_ttl_first_zset";
+
+        // TTL at position 0 for zset
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {} (ttl bigint, member text, score text)
+             SERVER {} OPTIONS (
+                database '{}', table_type 'zset', table_key_prefix '{}', ttl '3600'
+             );",
+            table_name, SERVER_NAME, TEST_DATABASE, key_prefix
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "INSERT INTO {} (member, score) VALUES ('p1', 10), ('p2', 20), ('p3', 30);",
+            table_name
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_ttl_zset_local (name text);").unwrap();
+        Spi::run("INSERT INTO join_ttl_zset_local VALUES ('p1'), ('p2'), ('missing');").unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_ttl_zset_local l JOIN {} r ON l.name = r.member;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 2, "JOIN with TTL-first zset should match p1 and p2");
+
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'p1';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'p2';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'p3';", table_name)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_ttl_zset_local;");
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_fdw_hash_to_hash_ttl_first() {
+        setup_join_fdw();
+
+        let table1 = "join_ttl_fdw_h1";
+        let table2 = "join_ttl_fdw_h2";
+        let key1 = "join_test:ttl_fdw_h1";
+        let key2 = "join_test:ttl_fdw_h2";
+
+        // Both tables with TTL at position 0
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {} (ttl bigint, field text, value text)
+             SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}', ttl '3600'
+             );",
+            table1, SERVER_NAME, TEST_DATABASE, key1
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {} (ttl bigint, field text, value text)
+             SERVER {} OPTIONS (
+                database '{}', table_type 'hash', table_key_prefix '{}', ttl '3600'
+             );",
+            table2, SERVER_NAME, TEST_DATABASE, key2
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "INSERT INTO {} (field, value) VALUES ('k1', 'v1a'), ('k2', 'v2a');",
+            table1
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "INSERT INTO {} (field, value) VALUES ('k1', 'v1b'), ('k3', 'v3b');",
+            table2
+        ))
+        .unwrap();
+
+        // FDW-to-FDW join with TTL at position 0 on both sides
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM {} t1 JOIN {} t2 ON t1.field = t2.field;",
+            table1, table2
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            count, 1,
+            "FDW-to-FDW with TTL-first should find 1 match (k1)"
+        );
+
+        // LEFT JOIN
+        let left_count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM {} t1 LEFT JOIN {} t2 ON t1.field = t2.field;",
+            table1, table2
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(left_count, 2, "LEFT JOIN should return both rows from t1");
+
+        // Verify content
+        let val = Spi::get_one::<String>(&format!(
+            "SELECT t2.value FROM {} t1 JOIN {} t2 ON t1.field = t2.field WHERE t1.field = 'k1';",
+            table1, table2
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            val, "v1b",
+            "Should get correct value from t2 via TTL-first join"
+        );
+
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'k1';", table1)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'k2';", table1)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'k1';", table2)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE field = 'k3';", table2)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table1));
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table2));
+        cleanup_join_fdw();
+    }
+
+    #[pg_test]
+    fn test_join_set_ttl_first_with_local() {
+        setup_join_fdw();
+
+        let key_prefix = "join_test:ttl_first_set";
+        let table_name = "join_ttl_first_set";
+
+        // Set with TTL at position 0
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {} (ttl bigint, member text)
+             SERVER {} OPTIONS (
+                database '{}', table_type 'set', table_key_prefix '{}', ttl '3600'
+             );",
+            table_name, SERVER_NAME, TEST_DATABASE, key_prefix
+        ))
+        .unwrap();
+
+        Spi::run(&format!(
+            "INSERT INTO {} (member) VALUES ('m1'), ('m2'), ('m3');",
+            table_name
+        ))
+        .unwrap();
+
+        Spi::run("CREATE TEMPORARY TABLE join_ttl_set_local (id text);").unwrap();
+        Spi::run("INSERT INTO join_ttl_set_local VALUES ('m1'), ('m2'), ('missing');").unwrap();
+
+        let count = Spi::get_one::<i64>(&format!(
+            "SELECT COUNT(*) FROM join_ttl_set_local l JOIN {} r ON l.id = r.member;",
+            table_name
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(count, 2, "SET JOIN with TTL-first should match m1 and m2");
+
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'm1';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'm2';", table_name)).unwrap();
+        Spi::run(&format!("DELETE FROM {} WHERE member = 'm3';", table_name)).unwrap();
+        let _ = Spi::run(&format!("DROP FOREIGN TABLE IF EXISTS {};", table_name));
+        let _ = Spi::run("DROP TABLE IF EXISTS join_ttl_set_local;");
+        cleanup_join_fdw();
+    }
 }

--- a/src/tests/pushdown_verification_tests.rs
+++ b/src/tests/pushdown_verification_tests.rs
@@ -346,4 +346,165 @@ mod tests {
         teardown_fdw(table);
         cleanup_redis_key(key);
     }
+
+    #[pg_test]
+    fn test_pushdown_verify_zset_score_gte_uses_zrangebyscore() {
+        let table = "pv_zset_score_gte";
+        let key = "pv_test:zset_score_gte";
+        cleanup_redis_key(key);
+        setup_fdw(table, "member text, score numeric", "zset", key);
+
+        for i in 0..100 {
+            Spi::run(&format!("INSERT INTO {table} VALUES ('m{i}', {i});")).unwrap();
+        }
+
+        let before = get_all_command_counts();
+        let count = get_count(&format!("SELECT COUNT(*) FROM {table} WHERE score >= 90"));
+        let after = get_all_command_counts();
+
+        assert_eq!(count, 10, "score >= 90 should return 10 members (90..99)");
+
+        let zrangebyscore_delta = command_delta(&before, &after, "zrangebyscore");
+        assert!(
+            zrangebyscore_delta >= 1,
+            "Expected ZRANGEBYSCORE for >= pushdown, but delta={}",
+            zrangebyscore_delta
+        );
+
+        teardown_fdw(table);
+        cleanup_redis_key(key);
+    }
+
+    #[pg_test]
+    fn test_pushdown_verify_zset_score_range_uses_zrangebyscore() {
+        let table = "pv_zset_score_range";
+        let key = "pv_test:zset_score_range";
+        cleanup_redis_key(key);
+        setup_fdw(table, "member text, score numeric", "zset", key);
+
+        for i in 0..100 {
+            Spi::run(&format!("INSERT INTO {table} VALUES ('m{i}', {i});")).unwrap();
+        }
+
+        let before = get_all_command_counts();
+        let count = get_count(&format!(
+            "SELECT COUNT(*) FROM {table} WHERE score >= 20 AND score <= 30"
+        ));
+        let after = get_all_command_counts();
+
+        assert_eq!(count, 11, "20 <= score <= 30 should return 11 members");
+
+        let zrangebyscore_delta = command_delta(&before, &after, "zrangebyscore");
+        assert!(
+            zrangebyscore_delta >= 1,
+            "Expected ZRANGEBYSCORE for range pushdown, but delta={}",
+            zrangebyscore_delta
+        );
+
+        teardown_fdw(table);
+        cleanup_redis_key(key);
+    }
+
+    #[pg_test]
+    fn test_pushdown_verify_zset_score_gt_exclusive() {
+        let table = "pv_zset_score_gt";
+        let key = "pv_test:zset_score_gt";
+        cleanup_redis_key(key);
+        setup_fdw(table, "member text, score numeric", "zset", key);
+
+        for i in 0..50 {
+            Spi::run(&format!("INSERT INTO {table} VALUES ('m{i}', {i});")).unwrap();
+        }
+
+        let count = get_count(&format!("SELECT COUNT(*) FROM {table} WHERE score > 45"));
+        assert_eq!(count, 4, "score > 45 should return 4 members (46,47,48,49)");
+
+        teardown_fdw(table);
+        cleanup_redis_key(key);
+    }
+
+    #[pg_test]
+    fn test_pushdown_verify_zset_score_lt_uses_zrangebyscore() {
+        let table = "pv_zset_score_lt";
+        let key = "pv_test:zset_score_lt";
+        cleanup_redis_key(key);
+        setup_fdw(table, "member text, score numeric", "zset", key);
+
+        for i in 0..100 {
+            Spi::run(&format!("INSERT INTO {table} VALUES ('m{i}', {i});")).unwrap();
+        }
+
+        let before = get_all_command_counts();
+        let count = get_count(&format!("SELECT COUNT(*) FROM {table} WHERE score < 5"));
+        let after = get_all_command_counts();
+
+        assert_eq!(count, 5, "score < 5 should return 5 members (0,1,2,3,4)");
+
+        let zrangebyscore_delta = command_delta(&before, &after, "zrangebyscore");
+        assert!(
+            zrangebyscore_delta >= 1,
+            "Expected ZRANGEBYSCORE for < pushdown, but delta={}",
+            zrangebyscore_delta
+        );
+
+        teardown_fdw(table);
+        cleanup_redis_key(key);
+    }
+
+    #[pg_test]
+    fn test_pushdown_verify_zset_score_range_with_ttl_first() {
+        let table = "pv_zset_score_ttl";
+        let key = "pv_test:zset_score_ttl";
+        cleanup_redis_key(key);
+
+        let wrapper = format!("pv_{}_wrapper", table);
+        let server = format!("pv_{}_server", table);
+        Spi::run(&format!(
+            "CREATE FOREIGN DATA WRAPPER {wrapper} HANDLER redis_fdw_handler;"
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "CREATE SERVER {server} FOREIGN DATA WRAPPER {wrapper} \
+             OPTIONS (host_port '127.0.0.1:8899');"
+        ))
+        .unwrap();
+        Spi::run(&format!(
+            "CREATE FOREIGN TABLE {table} (ttl bigint, member text, score numeric) \
+             SERVER {server} OPTIONS (\
+               database '15', \
+               table_type 'zset', \
+               table_key_prefix '{key}', \
+               ttl '600'\
+             );"
+        ))
+        .unwrap();
+
+        for i in 0..50 {
+            Spi::run(&format!(
+                "INSERT INTO {table} (member, score) VALUES ('player{i}', {});",
+                i * 10
+            ))
+            .unwrap();
+        }
+
+        let count = get_count(&format!("SELECT COUNT(*) FROM {table} WHERE score >= 400"));
+        assert_eq!(
+            count, 10,
+            "score >= 400 with TTL-first should return 10 members (40..49)"
+        );
+
+        let before = get_all_command_counts();
+        let _ = get_count(&format!("SELECT COUNT(*) FROM {table} WHERE score >= 400"));
+        let after = get_all_command_counts();
+
+        let zrangebyscore_delta = command_delta(&before, &after, "zrangebyscore");
+        assert!(
+            zrangebyscore_delta >= 1,
+            "Expected ZRANGEBYSCORE even with TTL at position 0, but delta={}",
+            zrangebyscore_delta
+        );
+
+        teardown_fdw(table);
+        cleanup_redis_key(key);
+    }
 }


### PR DESCRIPTION
- Fix ZRANGEBYSCORE LIMIT: always emit LIMIT arg when offset/limit present
- Guard range-condition direct load to ZSet type only (was triggering for all types)
- Allow multi-key String tables in FDW-to-FDW join pushdown (only reject single-key)
- Reorder ZSet load_data: check member equality (O(1) ZSCORE) before score range (O(log N+M) ZRANGEBYSCORE)
- ZSet score-range: intersect multiple bounds (max of lower, min of upper)
- should_use_direct_load checks score_column_index specifically, not just any range op
- LIMIT default uses usize::MAX.min(i64::MAX as usize) for 32-bit safety